### PR TITLE
fix: 競技委員削除機能の修正

### DIFF
--- a/app/Http/Controllers/Admin/CompetitionController.php
+++ b/app/Http/Controllers/Admin/CompetitionController.php
@@ -48,6 +48,13 @@ class CompetitionController extends Controller
             'committee_members.*' => 'string|max:255',
         ]);
 
+        // 競技委員の配列から空の値を除去
+        if (isset($validated['committee_members'])) {
+            $validated['committee_members'] = array_values(array_filter($validated['committee_members'], function($member) {
+                return !empty(trim($member));
+            }));
+        }
+
         \Log::info('Validated data:', $validated);
 
         Competition::create($validated);
@@ -91,6 +98,13 @@ class CompetitionController extends Controller
             'committee_members' => 'nullable|array',
             'committee_members.*' => 'string|max:255',
         ]);
+
+        // 競技委員の配列から空の値を除去
+        if (isset($validated['committee_members'])) {
+            $validated['committee_members'] = array_values(array_filter($validated['committee_members'], function($member) {
+                return !empty(trim($member));
+            }));
+        }
 
         \Log::info('Validated data:', $validated);
 

--- a/resources/js/components/CommitteeMemberInput.vue
+++ b/resources/js/components/CommitteeMemberInput.vue
@@ -62,13 +62,13 @@
     </p>
 
     <!-- 隠しフィールドで配列データをサーバーに送信 -->
-    <input 
-      v-for="(member, index) in members" 
-      :key="`member-${index}`"
-      type="hidden" 
-      :name="`committee_members[${index}]`" 
-      :value="member"
-    >
+    <template v-for="(member, index) in members" :key="`member-hidden-${index}`">
+      <input 
+        type="hidden" 
+        :name="`committee_members[${index}]`" 
+        :value="member"
+      >
+    </template>
   </div>
 </template>
 


### PR DESCRIPTION
## Summary
- 競技委員削除時の配列インデックス管理の問題を修正
- 削除ボタンを押して更新しても正しく反映されるように改善

## Changes
- Vue.jsコンポーネント（CommitteeMemberInput.vue）で隠しフィールドのキー管理を改善
- CompetitionController.phpのstore/updateメソッドで空の配列値をフィルタリングする処理を追加

## Test plan
- [ ] 大会編集画面で競技委員を追加できることを確認
- [ ] 競技委員を削除して更新ボタンを押すと、正しく削除が反映されることを確認
- [ ] 複数の競技委員を削除しても正常に動作することを確認
- [ ] 競技委員の並び替え（ドラッグ&ドロップ）が正常に動作することを確認

## Notes
npm のビルド環境に問題があるため、開発環境で Vue.js のホットリロードを使用して動作確認することを推奨します。

🤖 Generated with [Claude Code](https://claude.ai/code)