### PR TITLE
feat: 端末管理機能の完全実装

### DIFF
--- a/app/Http/Controllers/Admin/CompetitionDeviceController.php
+++ b/app/Http/Controllers/Admin/CompetitionDeviceController.php
@@ -1,0 +1,339 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Competition;
+use App\Models\CompetitionDevice;
+use App\Models\Device;
+use App\Models\CompetitionPlayer;
+use Illuminate\Http\Request;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\JsonResponse;
+use Illuminate\View\View;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+
+class CompetitionDeviceController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(Request $request): View|JsonResponse
+    {
+        $query = CompetitionDevice::with(['competition', 'device']);
+
+        // 大会でフィルタ
+        if ($request->filled('competition_id')) {
+            $query->forCompetition($request->competition_id);
+        }
+
+        // 検索
+        if ($request->filled('search')) {
+            $query->search($request->search);
+        }
+
+        $competitionDevices = $query->orderBy('player_number')->paginate(20)->withQueryString();
+        $competitions = Competition::orderBy('start_date', 'desc')->get();
+
+        if ($request->wantsJson()) {
+            return response()->json($competitionDevices);
+        }
+
+        return view('admin.competition-devices.index', compact('competitionDevices', 'competitions'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create(Request $request): View
+    {
+        $competitions = Competition::orderBy('start_date', 'desc')->get();
+        $devices = Device::forPlayers()->orderBy('name')->get();
+        
+        // 選択された大会がある場合
+        $selectedCompetition = null;
+        $assignedDevices = collect();
+        $availablePlayers = collect();
+        
+        if ($request->filled('competition_id')) {
+            $selectedCompetition = Competition::find($request->competition_id);
+            if ($selectedCompetition) {
+                // すでに割り当てられている端末を取得
+                $assignedDevices = CompetitionDevice::where('competition_id', $selectedCompetition->id)
+                    ->pluck('device_id');
+                
+                // この大会に参加している選手を取得
+                $availablePlayers = CompetitionPlayer::where('competition_id', $selectedCompetition->id)
+                    ->with('player')
+                    ->orderBy('player_number')
+                    ->get();
+            }
+        }
+        
+        return view('admin.competition-devices.create', compact(
+            'competitions', 
+            'devices', 
+            'selectedCompetition', 
+            'assignedDevices',
+            'availablePlayers'
+        ));
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'competition_id' => 'required|exists:competitions,id',
+            'device_id' => 'required|exists:devices,id',
+            'player_number' => 'required|string|max:255',
+        ]);
+
+        // 重複チェック
+        $exists = CompetitionDevice::where('competition_id', $validated['competition_id'])
+            ->where(function ($query) use ($validated) {
+                $query->where('device_id', $validated['device_id'])
+                      ->orWhere('player_number', $validated['player_number']);
+            })
+            ->exists();
+
+        if ($exists) {
+            return redirect()->back()
+                ->withInput()
+                ->with('error', 'この端末または選手番号はすでに登録されています。');
+        }
+
+        CompetitionDevice::create($validated);
+
+        return redirect()->route('admin.competition-devices.index')
+            ->with('success', '端末を割り当てました。');
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(CompetitionDevice $competitionDevice): View
+    {
+        $competitionDevice->load(['competition', 'device']);
+        
+        return view('admin.competition-devices.show', compact('competitionDevice'));
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(CompetitionDevice $competitionDevice): View
+    {
+        $competitions = Competition::orderBy('start_date', 'desc')->get();
+        $devices = Device::forPlayers()->orderBy('name')->get();
+        
+        // この大会に参加している選手を取得
+        $availablePlayers = CompetitionPlayer::where('competition_id', $competitionDevice->competition_id)
+            ->with('player')
+            ->orderBy('player_number')
+            ->get();
+        
+        return view('admin.competition-devices.edit', compact(
+            'competitionDevice', 
+            'competitions', 
+            'devices',
+            'availablePlayers'
+        ));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, CompetitionDevice $competitionDevice): RedirectResponse
+    {
+        $validated = $request->validate([
+            'player_number' => 'required|string|max:255',
+        ]);
+
+        // 重複チェック（自分自身を除く）
+        $exists = CompetitionDevice::where('competition_id', $competitionDevice->competition_id)
+            ->where('player_number', $validated['player_number'])
+            ->where('id', '!=', $competitionDevice->id)
+            ->exists();
+
+        if ($exists) {
+            return redirect()->back()
+                ->withInput()
+                ->with('error', 'この選手番号はすでに使用されています。');
+        }
+
+        $competitionDevice->update($validated);
+
+        return redirect()->route('admin.competition-devices.index')
+            ->with('success', '割り当てを更新しました。');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(CompetitionDevice $competitionDevice): RedirectResponse
+    {
+        $competitionDevice->delete();
+
+        return redirect()->route('admin.competition-devices.index')
+            ->with('success', '割り当てを解除しました。');
+    }
+
+    /**
+     * CSVエクスポート
+     */
+    public function export(Request $request): BinaryFileResponse
+    {
+        $query = CompetitionDevice::with(['competition', 'device']);
+
+        // 大会でフィルタ
+        if ($request->filled('competition_id')) {
+            $query->forCompetition($request->competition_id);
+            $competition = Competition::find($request->competition_id);
+            $filename = $competition->name . '_端末割当_' . now()->format('Ymd_His') . '.csv';
+        } else {
+            $filename = '端末割当一覧_' . now()->format('Ymd_His') . '.csv';
+        }
+
+        $competitionDevices = $query->orderBy('player_number')->get();
+        
+        $path = 'exports/' . $filename;
+        
+        // UTF-8 BOM付きでCSVを作成
+        $csv = chr(0xEF) . chr(0xBB) . chr(0xBF);
+        $csv .= implode(',', CompetitionDevice::getCsvHeaders()) . "\n";
+        
+        foreach ($competitionDevices as $competitionDevice) {
+            $data = $competitionDevice->toCsvArray();
+            $csv .= implode(',', array_map(function ($item) {
+                return '"' . str_replace('"', '""', $item) . '"';
+            }, $data)) . "\n";
+        }
+        
+        Storage::put($path, $csv);
+        
+        return response()->download(storage_path('app/' . $path), $filename)
+            ->deleteFileAfterSend(true);
+    }
+
+    /**
+     * CSVインポート
+     */
+    public function import(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'competition_id' => 'required|exists:competitions,id',
+            'csv_file' => 'required|file|mimes:csv,txt|max:2048',
+        ]);
+
+        $competitionId = $request->competition_id;
+        $file = $request->file('csv_file');
+        $content = file_get_contents($file->getRealPath());
+        
+        // BOMを除去
+        $content = str_replace("\xEF\xBB\xBF", '', $content);
+        
+        // 改行で分割
+        $lines = array_filter(explode("\n", $content));
+        
+        // ヘッダー行をスキップ
+        array_shift($lines);
+        
+        $imported = 0;
+        $errors = [];
+
+        DB::beginTransaction();
+        try {
+            foreach ($lines as $index => $line) {
+                $data = str_getcsv($line);
+                
+                if (count($data) < 2) {
+                    $errors[] = '行 ' . ($index + 2) . ': データが不足しています';
+                    continue;
+                }
+
+                $playerNumber = trim($data[0] ?? '');
+                $deviceName = trim($data[1] ?? '');
+
+                // 必須項目のチェック
+                if (empty($playerNumber) || empty($deviceName)) {
+                    $errors[] = '行 ' . ($index + 2) . ': 必須項目が不足しています';
+                    continue;
+                }
+
+                // 端末の検索
+                $device = Device::where('name', $deviceName)
+                    ->where('user_type', '選手')
+                    ->first();
+
+                if (!$device) {
+                    $errors[] = '行 ' . ($index + 2) . ': 端末「' . $deviceName . '」が見つかりません';
+                    continue;
+                }
+
+                // 重複チェック
+                $exists = CompetitionDevice::where('competition_id', $competitionId)
+                    ->where(function ($query) use ($device, $playerNumber) {
+                        $query->where('device_id', $device->id)
+                              ->orWhere('player_number', $playerNumber);
+                    })
+                    ->exists();
+
+                if ($exists) {
+                    $errors[] = '行 ' . ($index + 2) . ': この端末または選手番号はすでに登録されています';
+                    continue;
+                }
+
+                CompetitionDevice::create([
+                    'competition_id' => $competitionId,
+                    'device_id' => $device->id,
+                    'player_number' => $playerNumber,
+                ]);
+
+                $imported++;
+            }
+
+            DB::commit();
+
+            $message = $imported . '件の割り当てをインポートしました。';
+            if (!empty($errors)) {
+                $message .= ' (' . count($errors) . '件のエラーがありました)';
+            }
+
+            return redirect()->route('admin.competition-devices.index')
+                ->with('success', $message)
+                ->with('import_errors', $errors);
+
+        } catch (\Exception $e) {
+            DB::rollBack();
+            return redirect()->route('admin.competition-devices.index')
+                ->with('error', 'インポート中にエラーが発生しました: ' . $e->getMessage());
+        }
+    }
+
+    /**
+     * 選手番号の候補を取得（AJAX用）
+     */
+    public function getAvailablePlayerNumbers(Request $request): JsonResponse
+    {
+        $request->validate([
+            'competition_id' => 'required|exists:competitions,id',
+        ]);
+
+        $playerNumbers = CompetitionPlayer::where('competition_id', $request->competition_id)
+            ->with('player')
+            ->orderBy('player_number')
+            ->get()
+            ->map(function ($cp) {
+                return [
+                    'player_number' => $cp->player_number,
+                    'player_name' => $cp->player->name,
+                ];
+            });
+
+        return response()->json($playerNumbers);
+    }
+}

--- a/app/Http/Controllers/Admin/CompetitionDeviceController.php
+++ b/app/Http/Controllers/Admin/CompetitionDeviceController.php
@@ -202,6 +202,11 @@ class CompetitionDeviceController extends Controller
         
         $path = 'exports/' . $filename;
         
+        // exportsディレクトリが存在しない場合は作成
+        if (!Storage::exists('exports')) {
+            Storage::makeDirectory('exports');
+        }
+        
         // UTF-8 BOM付きでCSVを作成
         $csv = chr(0xEF) . chr(0xBB) . chr(0xBF);
         $csv .= implode(',', CompetitionDevice::getCsvHeaders()) . "\n";

--- a/app/Http/Controllers/Admin/DeviceController.php
+++ b/app/Http/Controllers/Admin/DeviceController.php
@@ -134,6 +134,11 @@ class DeviceController extends Controller
         $filename = '端末一覧_' . now()->format('Ymd_His') . '.csv';
         $path = 'exports/' . $filename;
         
+        // exportsディレクトリが存在しない場合は作成
+        if (!Storage::exists('exports')) {
+            Storage::makeDirectory('exports');
+        }
+        
         // UTF-8 BOM付きでCSVを作成（Excelで文字化けしないように）
         $csv = chr(0xEF) . chr(0xBB) . chr(0xBF);
         $csv .= implode(',', Device::getCsvHeaders()) . "\n";

--- a/app/Http/Controllers/Admin/DeviceController.php
+++ b/app/Http/Controllers/Admin/DeviceController.php
@@ -8,7 +8,6 @@ use Illuminate\Http\Request;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\View\View;
 use Illuminate\Support\Facades\DB;
-use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Response;
@@ -128,50 +127,53 @@ class DeviceController extends Controller
     /**
      * CSVエクスポート
      */
-    public function export(): Response
+    public function export(Request $request): Response
     {
-        try {
-            $devices = Device::orderBy('name')->get();
-            
-            $filename = '端末一覧_' . now()->format('Ymd_His') . '.csv';
-            $path = 'exports/' . $filename;
-            
-            // exportsディレクトリが存在しない場合は作成
-            if (!Storage::exists('exports')) {
-                Storage::makeDirectory('exports');
-            }
-            
-            // UTF-8 BOM付きでCSVを作成（Excelで文字化けしないように）
-            $csv = chr(0xEF) . chr(0xBB) . chr(0xBF);
-            $csv .= implode(',', Device::getCsvHeaders()) . "\n";
-            
-            foreach ($devices as $device) {
-                $data = $device->toCsvArray();
-                $csv .= implode(',', array_map(function ($item) {
-                    return '"' . str_replace('"', '""', $item) . '"';
-                }, $data)) . "\n";
-            }
-            
-            // ファイルの書き込みを試行
-            $result = Storage::put($path, $csv);
-            
-            if (!$result) {
-                throw new \Exception('CSV ファイルの作成に失敗しました');
-            }
-            
-            $fullPath = storage_path('app/' . $path);
-            
-            if (!file_exists($fullPath)) {
-                throw new \Exception('CSV ファイルが作成されませんでした: ' . $fullPath);
-            }
-            
-            return response()->download($fullPath, $filename)
-                ->deleteFileAfterSend(true);
-                
-        } catch (\Exception $e) {
-            return redirect()->route('admin.devices.index')
-                ->with('error', 'CSVエクスポートでエラーが発生しました: ' . $e->getMessage());
+        $query = Device::query();
+
+        // 検索フィルタ適用
+        if ($request->filled('search')) {
+            $query->search($request->search);
         }
+        if ($request->filled('type')) {
+            $query->ofType($request->type);
+        }
+        if ($request->filled('user_type')) {
+            $query->ofUserType($request->user_type);
+        }
+
+        $devices = $query->orderBy('name')->get();
+
+        $csvData = [];
+        
+        // ヘッダー行を追加
+        $csvData[] = Device::getCsvHeaders();
+
+        // データ行を追加
+        foreach ($devices as $device) {
+            $csvData[] = $device->toCsvArray();
+        }
+
+        // CSV文字列を生成
+        $csv = '';
+        foreach ($csvData as $row) {
+            $csv .= implode(',', array_map(function($field) {
+                if (strpos($field, ',') !== false || strpos($field, "\n") !== false || strpos($field, '"') !== false) {
+                    $field = '"' . str_replace('"', '""', $field) . '"';
+                }
+                return $field;
+            }, $row)) . "\n";
+        }
+
+        // BOMを追加（Excel での文字化け防止）
+        $csv = "\xEF\xBB\xBF" . $csv;
+
+        $filename = '端末一覧_' . date('Y-m-d') . '.csv';
+        $encodedFilename = rawurlencode($filename);
+        
+        return response($csv)
+            ->header('Content-Type', 'text/csv; charset=UTF-8')
+            ->header('Content-Disposition', 'attachment; filename="' . $filename . '"; filename*=UTF-8\'\'' . $encodedFilename);
     }
 
     /**

--- a/app/Http/Controllers/Admin/DeviceController.php
+++ b/app/Http/Controllers/Admin/DeviceController.php
@@ -1,0 +1,252 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Device;
+use Illuminate\Http\Request;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\View\View;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+
+class DeviceController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(Request $request): View
+    {
+        $query = Device::query();
+
+        // 検索
+        if ($request->filled('search')) {
+            $query->search($request->search);
+        }
+
+        // 端末種別でフィルタ
+        if ($request->filled('type')) {
+            $query->ofType($request->type);
+        }
+
+        // 利用者種別でフィルタ
+        if ($request->filled('user_type')) {
+            $query->ofUserType($request->user_type);
+        }
+
+        $devices = $query->latest()->paginate(20)->withQueryString();
+
+        return view('admin.devices.index', compact('devices'));
+    }
+
+    /**
+     * Show the form for creating a new resource.
+     */
+    public function create(): View
+    {
+        return view('admin.devices.create');
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request): RedirectResponse
+    {
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'type' => 'required|in:PC,スマートフォン,その他',
+            'user_type' => 'required|in:選手,競技関係者,ネットワーク',
+            'ip_address' => 'nullable|ip',
+            'mac_address' => 'nullable|string|regex:/^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$/|max:17',
+        ]);
+
+        Device::create($validated);
+
+        return redirect()->route('admin.devices.index')
+            ->with('success', '端末を登録しました。');
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Device $device): View
+    {
+        $device->load(['competitions' => function ($query) {
+            $query->orderBy('start_date', 'desc');
+        }]);
+        
+        return view('admin.devices.show', compact('device'));
+    }
+
+    /**
+     * Show the form for editing the specified resource.
+     */
+    public function edit(Device $device): View
+    {
+        return view('admin.devices.edit', compact('device'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Device $device): RedirectResponse
+    {
+        $validated = $request->validate([
+            'name' => 'required|string|max:255',
+            'type' => 'required|in:PC,スマートフォン,その他',
+            'user_type' => 'required|in:選手,競技関係者,ネットワーク',
+            'ip_address' => 'nullable|ip',
+            'mac_address' => 'nullable|string|regex:/^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$/|max:17',
+        ]);
+
+        $device->update($validated);
+
+        return redirect()->route('admin.devices.index')
+            ->with('success', '端末情報を更新しました。');
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Device $device): RedirectResponse
+    {
+        // 大会に割り当てられている場合は削除不可
+        if ($device->competitions()->exists()) {
+            return redirect()->route('admin.devices.index')
+                ->with('error', 'この端末は大会に割り当てられているため削除できません。');
+        }
+
+        $device->delete();
+
+        return redirect()->route('admin.devices.index')
+            ->with('success', '端末を削除しました。');
+    }
+
+    /**
+     * CSVエクスポート
+     */
+    public function export(): BinaryFileResponse
+    {
+        $devices = Device::orderBy('name')->get();
+        
+        $filename = '端末一覧_' . now()->format('Ymd_His') . '.csv';
+        $path = 'exports/' . $filename;
+        
+        // UTF-8 BOM付きでCSVを作成（Excelで文字化けしないように）
+        $csv = chr(0xEF) . chr(0xBB) . chr(0xBF);
+        $csv .= implode(',', Device::getCsvHeaders()) . "\n";
+        
+        foreach ($devices as $device) {
+            $data = $device->toCsvArray();
+            $csv .= implode(',', array_map(function ($item) {
+                return '"' . str_replace('"', '""', $item) . '"';
+            }, $data)) . "\n";
+        }
+        
+        Storage::put($path, $csv);
+        
+        return response()->download(storage_path('app/' . $path), $filename)
+            ->deleteFileAfterSend(true);
+    }
+
+    /**
+     * CSVインポート
+     */
+    public function import(Request $request): RedirectResponse
+    {
+        $request->validate([
+            'csv_file' => 'required|file|mimes:csv,txt|max:2048',
+        ]);
+
+        $file = $request->file('csv_file');
+        $content = file_get_contents($file->getRealPath());
+        
+        // BOMを除去
+        $content = str_replace("\xEF\xBB\xBF", '', $content);
+        
+        // 改行で分割
+        $lines = array_filter(explode("\n", $content));
+        
+        // ヘッダー行をスキップ
+        array_shift($lines);
+        
+        $imported = 0;
+        $errors = [];
+
+        DB::beginTransaction();
+        try {
+            foreach ($lines as $index => $line) {
+                $data = str_getcsv($line);
+                
+                if (count($data) < 3) {
+                    $errors[] = '行 ' . ($index + 2) . ': データが不足しています';
+                    continue;
+                }
+
+                $name = trim($data[0] ?? '');
+                $type = trim($data[1] ?? '');
+                $userType = trim($data[2] ?? '');
+                $ipAddress = trim($data[3] ?? '');
+                $macAddress = trim($data[4] ?? '');
+
+                // 必須項目のチェック
+                if (empty($name) || empty($type) || empty($userType)) {
+                    $errors[] = '行 ' . ($index + 2) . ': 必須項目が不足しています';
+                    continue;
+                }
+
+                // 端末種別の検証
+                if (!in_array($type, array_keys(Device::getTypes()))) {
+                    $errors[] = '行 ' . ($index + 2) . ': 無効な端末種別です';
+                    continue;
+                }
+
+                // 利用者種別の検証
+                if (!in_array($userType, array_keys(Device::getUserTypes()))) {
+                    $errors[] = '行 ' . ($index + 2) . ': 無効な利用者種別です';
+                    continue;
+                }
+
+                // IPアドレスの検証（入力されている場合）
+                if (!empty($ipAddress) && !filter_var($ipAddress, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4)) {
+                    $errors[] = '行 ' . ($index + 2) . ': 無効なIPアドレスです';
+                    continue;
+                }
+
+                // MACアドレスの検証（入力されている場合）
+                if (!empty($macAddress) && !preg_match('/^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$/', $macAddress)) {
+                    $errors[] = '行 ' . ($index + 2) . ': 無効なMACアドレスです';
+                    continue;
+                }
+
+                Device::create([
+                    'name' => $name,
+                    'type' => $type,
+                    'user_type' => $userType,
+                    'ip_address' => $ipAddress ?: null,
+                    'mac_address' => $macAddress ?: null,
+                ]);
+
+                $imported++;
+            }
+
+            DB::commit();
+
+            $message = $imported . '件の端末をインポートしました。';
+            if (!empty($errors)) {
+                $message .= ' (' . count($errors) . '件のエラーがありました)';
+            }
+
+            return redirect()->route('admin.devices.index')
+                ->with('success', $message)
+                ->with('import_errors', $errors);
+
+        } catch (\Exception $e) {
+            DB::rollBack();
+            return redirect()->route('admin.devices.index')
+                ->with('error', 'インポート中にエラーが発生しました: ' . $e->getMessage());
+        }
+    }
+}

--- a/app/Models/Competition.php
+++ b/app/Models/Competition.php
@@ -67,4 +67,22 @@ class Competition extends Model
         
         return $this->start_date->format('Y年m月d日') . ' 〜 ' . $this->end_date->format('Y年m月d日');
     }
+
+    /**
+     * 大会で使用する端末
+     */
+    public function devices(): BelongsToMany
+    {
+        return $this->belongsToMany(Device::class, 'competition_devices')
+            ->withPivot('player_number')
+            ->withTimestamps();
+    }
+
+    /**
+     * 大会の端末割り当て
+     */
+    public function competitionDevices(): HasMany
+    {
+        return $this->hasMany(CompetitionDevice::class);
+    }
 }

--- a/app/Models/CompetitionDevice.php
+++ b/app/Models/CompetitionDevice.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class CompetitionDevice extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'competition_id',
+        'device_id',
+        'player_number',
+    ];
+
+    /**
+     * この割り当てが属する大会を取得
+     */
+    public function competition(): BelongsTo
+    {
+        return $this->belongsTo(Competition::class);
+    }
+
+    /**
+     * この割り当てが属する端末を取得
+     */
+    public function device(): BelongsTo
+    {
+        return $this->belongsTo(Device::class);
+    }
+
+    /**
+     * 大会でフィルタリング
+     */
+    public function scopeForCompetition($query, $competitionId)
+    {
+        return $query->where('competition_id', $competitionId);
+    }
+
+    /**
+     * 検索スコープ
+     */
+    public function scopeSearch($query, $search)
+    {
+        return $query->where(function ($q) use ($search) {
+            $q->where('player_number', 'like', "%{$search}%")
+              ->orWhereHas('device', function ($q) use ($search) {
+                  $q->where('name', 'like', "%{$search}%")
+                    ->orWhere('ip_address', 'like', "%{$search}%")
+                    ->orWhere('mac_address', 'like', "%{$search}%");
+              });
+        });
+    }
+
+    /**
+     * CSVエクスポート用のデータ配列を取得
+     */
+    public function toCsvArray(): array
+    {
+        return [
+            $this->player_number,
+            $this->device->name,
+            $this->device->type,
+            $this->device->ip_address ?? '',
+            $this->device->mac_address ?? '',
+        ];
+    }
+
+    /**
+     * CSVヘッダーを取得
+     */
+    public static function getCsvHeaders(): array
+    {
+        return ['選手番号', '端末名', '端末種別', 'IPアドレス', 'MACアドレス'];
+    }
+
+    /**
+     * CSVインポート用のヘッダーを取得
+     */
+    public static function getImportCsvHeaders(): array
+    {
+        return ['選手番号', '端末名'];
+    }
+}

--- a/app/Models/CompetitionDevice.php
+++ b/app/Models/CompetitionDevice.php
@@ -61,11 +61,13 @@ class CompetitionDevice extends Model
     public function toCsvArray(): array
     {
         return [
+            $this->competition->name,
             $this->player_number,
             $this->device->name,
             $this->device->type,
             $this->device->ip_address ?? '',
             $this->device->mac_address ?? '',
+            $this->created_at->format('Y-m-d'),
         ];
     }
 
@@ -74,7 +76,7 @@ class CompetitionDevice extends Model
      */
     public static function getCsvHeaders(): array
     {
-        return ['選手番号', '端末名', '端末種別', 'IPアドレス', 'MACアドレス'];
+        return ['大会名', '選手番号', '端末名', '端末種別', 'IPアドレス', 'MACアドレス', '割り当て日'];
     }
 
     /**

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -114,6 +114,7 @@ class Device extends Model
             $this->user_type,
             $this->ip_address ?? '',
             $this->mac_address ?? '',
+            $this->created_at->format('Y-m-d'),
         ];
     }
 
@@ -122,6 +123,6 @@ class Device extends Model
      */
     public static function getCsvHeaders(): array
     {
-        return ['端末名', '端末種別', '利用者', 'IPアドレス', 'MACアドレス'];
+        return ['端末名', '端末種別', '利用者', 'IPアドレス', 'MACアドレス', '登録日'];
     }
 }

--- a/app/Models/Device.php
+++ b/app/Models/Device.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+
+class Device extends Model
+{
+    use HasFactory;
+
+    protected $fillable = [
+        'name',
+        'type',
+        'user_type',
+        'ip_address',
+        'mac_address',
+    ];
+
+    /**
+     * 端末種別の選択肢を取得
+     */
+    public static function getTypes(): array
+    {
+        return [
+            'PC' => 'PC',
+            'スマートフォン' => 'スマートフォン',
+            'その他' => 'その他',
+        ];
+    }
+
+    /**
+     * 利用者種別の選択肢を取得
+     */
+    public static function getUserTypes(): array
+    {
+        return [
+            '選手' => '選手',
+            '競技関係者' => '競技関係者',
+            'ネットワーク' => 'ネットワーク',
+        ];
+    }
+
+    /**
+     * この端末が割り当てられている大会を取得
+     */
+    public function competitions(): BelongsToMany
+    {
+        return $this->belongsToMany(Competition::class, 'competition_devices')
+            ->withPivot('player_number')
+            ->withTimestamps();
+    }
+
+    /**
+     * この端末の競技割り当てを取得
+     */
+    public function competitionDevices(): HasMany
+    {
+        return $this->hasMany(CompetitionDevice::class);
+    }
+
+    /**
+     * 検索スコープ
+     */
+    public function scopeSearch($query, $search)
+    {
+        return $query->where(function ($q) use ($search) {
+            $q->where('name', 'like', "%{$search}%")
+              ->orWhere('ip_address', 'like', "%{$search}%")
+              ->orWhere('mac_address', 'like', "%{$search}%");
+        });
+    }
+
+    /**
+     * 端末種別でフィルタリング
+     */
+    public function scopeOfType($query, $type)
+    {
+        if ($type) {
+            return $query->where('type', $type);
+        }
+        return $query;
+    }
+
+    /**
+     * 利用者種別でフィルタリング
+     */
+    public function scopeOfUserType($query, $userType)
+    {
+        if ($userType) {
+            return $query->where('user_type', $userType);
+        }
+        return $query;
+    }
+
+    /**
+     * 選手用端末のみを取得
+     */
+    public function scopeForPlayers($query)
+    {
+        return $query->where('user_type', '選手');
+    }
+
+    /**
+     * CSVエクスポート用のデータ配列を取得
+     */
+    public function toCsvArray(): array
+    {
+        return [
+            $this->name,
+            $this->type,
+            $this->user_type,
+            $this->ip_address ?? '',
+            $this->mac_address ?? '',
+        ];
+    }
+
+    /**
+     * CSVヘッダーを取得
+     */
+    public static function getCsvHeaders(): array
+    {
+        return ['端末名', '端末種別', '利用者', 'IPアドレス', 'MACアドレス'];
+    }
+}

--- a/database/migrations/2025_07_08_213000_create_devices_table.php
+++ b/database/migrations/2025_07_08_213000_create_devices_table.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('devices', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->comment('端末名');
+            $table->enum('type', ['PC', 'スマートフォン', 'その他'])->comment('端末種別');
+            $table->enum('user_type', ['選手', '競技関係者', 'ネットワーク'])->comment('利用者');
+            $table->string('ip_address', 15)->nullable()->comment('IPアドレス（IPv4）');
+            $table->string('mac_address', 17)->nullable()->comment('MACアドレス');
+            $table->timestamps();
+            
+            $table->index('name');
+            $table->index('type');
+            $table->index('user_type');
+            
+            $table->comment('端末管理テーブル');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('devices');
+    }
+};

--- a/database/migrations/2025_07_08_213001_create_competition_devices_table.php
+++ b/database/migrations/2025_07_08_213001_create_competition_devices_table.php
@@ -1,0 +1,39 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('competition_devices', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('competition_id')->constrained()->onDelete('cascade');
+            $table->foreignId('device_id')->constrained()->onDelete('cascade');
+            $table->string('player_number')->comment('選手番号');
+            $table->timestamps();
+            
+            // 一つの大会で同じ端末は一度しか割り当てられない
+            $table->unique(['competition_id', 'device_id']);
+            // 一つの大会で同じ選手番号は一度しか使えない
+            $table->unique(['competition_id', 'player_number']);
+            
+            $table->index('player_number');
+            
+            $table->comment('競技端末割り当てテーブル');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('competition_devices');
+    }
+};

--- a/resources/views/admin/competition-devices/create.blade.php
+++ b/resources/views/admin/competition-devices/create.blade.php
@@ -1,0 +1,221 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>端末割り当て - SJT-CP</title>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body class="bg-gray-50 min-h-screen">
+    <!-- ナビゲーションバー -->
+    <nav class="bg-white shadow-lg border-b border-gray-200">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex justify-between h-16">
+                <div class="flex items-center">
+                    <a href="{{ route('admin.home') }}" class="flex items-center">
+                        <div class="h-8 w-8 bg-blue-600 rounded-lg flex items-center justify-center mr-3">
+                            <svg class="h-5 w-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path>
+                            </svg>
+                        </div>
+                        <h1 class="text-xl font-bold text-gray-900">SJT-CP</h1>
+                    </a>
+                    <span class="ml-4 text-gray-400">|</span>
+                    <a href="{{ route('admin.competition-devices.index') }}" class="ml-4 text-gray-600 hover:text-gray-900">競技端末割り当て</a>
+                    <span class="ml-2 text-gray-400">></span>
+                    <span class="ml-2 text-gray-600 font-medium">新規割り当て</span>
+                </div>
+                <div class="flex items-center space-x-4">
+                    <span class="text-sm text-gray-700">{{ auth()->user()->name }}</span>
+                    <form method="POST" action="{{ route('logout') }}" class="inline">
+                        @csrf
+                        <button type="submit" class="text-sm text-gray-500 hover:text-gray-700">ログアウト</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <!-- メインコンテンツ -->
+    <main class="max-w-4xl mx-auto py-6 sm:px-6 lg:px-8">
+        <div class="px-4 sm:px-0">
+            <!-- ヘッダー -->
+            <div class="mb-8">
+                <h2 class="text-3xl font-bold text-gray-900">端末割り当て</h2>
+                <p class="text-gray-600 mt-2">選手用端末を大会の選手番号に割り当ててください。</p>
+            </div>
+
+            <!-- エラーメッセージ -->
+            @if($errors->any())
+                <div class="bg-red-50 border border-red-200 rounded-md p-4 mb-6">
+                    <div class="flex">
+                        <div class="flex-shrink-0">
+                            <svg class="h-5 w-5 text-red-400" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"></path>
+                            </svg>
+                        </div>
+                        <div class="ml-3">
+                            <h3 class="text-sm font-medium text-red-800">入力エラーがあります</h3>
+                            <ul class="mt-2 text-sm text-red-700 list-disc list-inside space-y-1">
+                                @foreach($errors->all() as $error)
+                                    <li>{{ $error }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            @endif
+
+            <!-- フォーム -->
+            <div class="bg-white shadow-xl rounded-xl overflow-hidden">
+                <div class="px-6 py-8">
+                    <form method="POST" action="{{ route('admin.competition-devices.store') }}" class="space-y-6">
+                        @csrf
+
+                        <!-- 大会選択 -->
+                        <div>
+                            <label for="competition_id" class="block text-sm font-semibold text-gray-700 mb-2">
+                                大会 <span class="text-red-500">*</span>
+                            </label>
+                            <select id="competition_id" 
+                                    name="competition_id" 
+                                    required
+                                    onchange="updateAvailablePlayers()"
+                                    class="block w-full px-3 py-3 border border-gray-300 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200 sm:text-sm">
+                                <option value="">選択してください</option>
+                                @foreach($competitions as $competition)
+                                    <option value="{{ $competition->id }}" 
+                                            {{ old('competition_id', $selectedCompetition?->id) == $competition->id ? 'selected' : '' }}>
+                                        {{ $competition->name }} ({{ $competition->period }})
+                                    </option>
+                                @endforeach
+                            </select>
+                            @error('competition_id')
+                                <div class="text-red-500 text-sm mt-1">{{ $message }}</div>
+                            @enderror
+                        </div>
+
+                        <!-- 端末選択 -->
+                        <div>
+                            <label for="device_id" class="block text-sm font-semibold text-gray-700 mb-2">
+                                端末 <span class="text-red-500">*</span>
+                            </label>
+                            <select id="device_id" 
+                                    name="device_id" 
+                                    required
+                                    class="block w-full px-3 py-3 border border-gray-300 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200 sm:text-sm">
+                                <option value="">選択してください</option>
+                                @foreach($devices as $device)
+                                    @if(!$assignedDevices->contains($device->id))
+                                        <option value="{{ $device->id }}" {{ old('device_id') == $device->id ? 'selected' : '' }}>
+                                            {{ $device->name }} ({{ $device->type }})
+                                            @if($device->ip_address) - {{ $device->ip_address }} @endif
+                                        </option>
+                                    @endif
+                                @endforeach
+                            </select>
+                            @error('device_id')
+                                <div class="text-red-500 text-sm mt-1">{{ $message }}</div>
+                            @enderror
+                            <p class="text-xs text-gray-500 mt-1">
+                                選手用端末のみ表示されています。すでに割り当て済みの端末は除外されています。
+                            </p>
+                        </div>
+
+                        <!-- 選手番号入力 -->
+                        <div>
+                            <label for="player_number" class="block text-sm font-semibold text-gray-700 mb-2">
+                                選手番号 <span class="text-red-500">*</span>
+                            </label>
+                            <div class="flex space-x-4">
+                                <input type="text" 
+                                       id="player_number" 
+                                       name="player_number" 
+                                       value="{{ old('player_number') }}"
+                                       required
+                                       placeholder="例：001、A-01"
+                                       class="flex-1 px-3 py-3 border border-gray-300 rounded-lg text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200 sm:text-sm">
+                                @if($availablePlayers->count() > 0)
+                                    <select id="player_select" 
+                                            onchange="selectPlayer()"
+                                            class="px-3 py-3 border border-gray-300 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200 sm:text-sm">
+                                        <option value="">参加選手から選択</option>
+                                        @foreach($availablePlayers as $player)
+                                            <option value="{{ $player->player_number }}" data-name="{{ $player->player->name }}">
+                                                {{ $player->player_number }} - {{ $player->player->name }}
+                                            </option>
+                                        @endforeach
+                                    </select>
+                                @endif
+                            </div>
+                            @error('player_number')
+                                <div class="text-red-500 text-sm mt-1">{{ $message }}</div>
+                            @enderror
+                            @if($availablePlayers->count() > 0)
+                                <p class="text-xs text-gray-500 mt-1">
+                                    直接入力するか、この大会に登録済みの選手から選択してください。
+                                </p>
+                            @endif
+                        </div>
+
+                        <!-- フォームボタン -->
+                        <div class="flex items-center justify-between pt-6 border-t border-gray-200">
+                            <a href="{{ route('admin.competition-devices.index') }}" 
+                               class="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-lg text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition duration-200">
+                                キャンセル
+                            </a>
+                            <button type="submit"
+                                    class="inline-flex items-center px-6 py-2 border border-transparent text-sm font-medium rounded-lg shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition duration-200">
+                                <svg class="h-5 w-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+                                </svg>
+                                割り当て
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <script>
+        function selectPlayer() {
+            const select = document.getElementById('player_select');
+            const input = document.getElementById('player_number');
+            if (select.value) {
+                input.value = select.value;
+            }
+        }
+
+        function updateAvailablePlayers() {
+            const competitionId = document.getElementById('competition_id').value;
+            const playerSelect = document.getElementById('player_select');
+            
+            if (!competitionId) {
+                if (playerSelect) {
+                    playerSelect.innerHTML = '<option value="">参加選手から選択</option>';
+                }
+                return;
+            }
+
+            // AJAX でその大会の選手一覧を取得
+            fetch(`/admin/api/competition-devices/player-numbers?competition_id=${competitionId}`)
+                .then(response => response.json())
+                .then(data => {
+                    if (playerSelect) {
+                        playerSelect.innerHTML = '<option value="">参加選手から選択</option>';
+                        data.forEach(player => {
+                            const option = document.createElement('option');
+                            option.value = player.player_number;
+                            option.textContent = `${player.player_number} - ${player.player_name}`;
+                            playerSelect.appendChild(option);
+                        });
+                    }
+                })
+                .catch(error => {
+                    console.error('Error fetching players:', error);
+                });
+        }
+    </script>
+</body>
+</html>

--- a/resources/views/admin/competition-devices/edit.blade.php
+++ b/resources/views/admin/competition-devices/edit.blade.php
@@ -1,0 +1,174 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>端末割り当て編集 - SJT-CP</title>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body class="bg-gray-50 min-h-screen">
+    <!-- ナビゲーションバー -->
+    <nav class="bg-white shadow-lg border-b border-gray-200">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex justify-between h-16">
+                <div class="flex items-center">
+                    <a href="{{ route('admin.home') }}" class="flex items-center">
+                        <div class="h-8 w-8 bg-blue-600 rounded-lg flex items-center justify-center mr-3">
+                            <svg class="h-5 w-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path>
+                            </svg>
+                        </div>
+                        <h1 class="text-xl font-bold text-gray-900">SJT-CP</h1>
+                    </a>
+                    <span class="ml-4 text-gray-400">|</span>
+                    <a href="{{ route('admin.competition-devices.index') }}" class="ml-4 text-gray-600 hover:text-gray-900">競技端末割り当て</a>
+                    <span class="ml-2 text-gray-400">></span>
+                    <span class="ml-2 text-gray-600 font-medium">編集</span>
+                </div>
+                <div class="flex items-center space-x-4">
+                    <span class="text-sm text-gray-700">{{ auth()->user()->name }}</span>
+                    <form method="POST" action="{{ route('logout') }}" class="inline">
+                        @csrf
+                        <button type="submit" class="text-sm text-gray-500 hover:text-gray-700">ログアウト</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <!-- メインコンテンツ -->
+    <main class="max-w-4xl mx-auto py-6 sm:px-6 lg:px-8">
+        <div class="px-4 sm:px-0">
+            <!-- ヘッダー -->
+            <div class="mb-8">
+                <h2 class="text-3xl font-bold text-gray-900">端末割り当て編集</h2>
+                <p class="text-gray-600 mt-2">選手番号を変更してください。</p>
+            </div>
+
+            <!-- エラーメッセージ -->
+            @if($errors->any())
+                <div class="bg-red-50 border border-red-200 rounded-md p-4 mb-6">
+                    <div class="flex">
+                        <div class="flex-shrink-0">
+                            <svg class="h-5 w-5 text-red-400" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"></path>
+                            </svg>
+                        </div>
+                        <div class="ml-3">
+                            <h3 class="text-sm font-medium text-red-800">入力エラーがあります</h3>
+                            <ul class="mt-2 text-sm text-red-700 list-disc list-inside space-y-1">
+                                @foreach($errors->all() as $error)
+                                    <li>{{ $error }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            @endif
+
+            <!-- 現在の割り当て情報 -->
+            <div class="bg-white shadow rounded-lg mb-6">
+                <div class="px-6 py-4">
+                    <h3 class="text-lg font-medium text-gray-900 mb-4">現在の割り当て情報</h3>
+                    <dl class="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2">
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">大会名</dt>
+                            <dd class="mt-1 text-sm text-gray-900 font-semibold">{{ $competitionDevice->competition->name }}</dd>
+                        </div>
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">開催期間</dt>
+                            <dd class="mt-1 text-sm text-gray-900">{{ $competitionDevice->competition->period }}</dd>
+                        </div>
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">端末名</dt>
+                            <dd class="mt-1 text-sm text-gray-900 font-semibold">{{ $competitionDevice->device->name }}</dd>
+                        </div>
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">端末種別</dt>
+                            <dd class="mt-1">
+                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium 
+                                    @if($competitionDevice->device->type === 'PC') bg-blue-100 text-blue-800
+                                    @elseif($competitionDevice->device->type === 'スマートフォン') bg-green-100 text-green-800
+                                    @else bg-gray-100 text-gray-800 @endif">
+                                    {{ $competitionDevice->device->type }}
+                                </span>
+                            </dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+
+            <!-- フォーム -->
+            <div class="bg-white shadow-xl rounded-xl overflow-hidden">
+                <div class="px-6 py-8">
+                    <form method="POST" action="{{ route('admin.competition-devices.update', $competitionDevice) }}" class="space-y-6">
+                        @csrf
+                        @method('PUT')
+
+                        <!-- 選手番号編集 -->
+                        <div>
+                            <label for="player_number" class="block text-sm font-semibold text-gray-700 mb-2">
+                                選手番号 <span class="text-red-500">*</span>
+                            </label>
+                            <div class="flex space-x-4">
+                                <input type="text" 
+                                       id="player_number" 
+                                       name="player_number" 
+                                       value="{{ old('player_number', $competitionDevice->player_number) }}"
+                                       required
+                                       placeholder="例：001、A-01"
+                                       class="flex-1 px-3 py-3 border border-gray-300 rounded-lg text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200 sm:text-sm">
+                                @if($availablePlayers->count() > 0)
+                                    <select id="player_select" 
+                                            onchange="selectPlayer()"
+                                            class="px-3 py-3 border border-gray-300 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200 sm:text-sm">
+                                        <option value="">参加選手から選択</option>
+                                        @foreach($availablePlayers as $player)
+                                            <option value="{{ $player->player_number }}" data-name="{{ $player->player->name }}">
+                                                {{ $player->player_number }} - {{ $player->player->name }}
+                                            </option>
+                                        @endforeach
+                                    </select>
+                                @endif
+                            </div>
+                            @error('player_number')
+                                <div class="text-red-500 text-sm mt-1">{{ $message }}</div>
+                            @enderror
+                            @if($availablePlayers->count() > 0)
+                                <p class="text-xs text-gray-500 mt-1">
+                                    直接入力するか、この大会に登録済みの選手から選択してください。
+                                </p>
+                            @endif
+                        </div>
+
+                        <!-- フォームボタン -->
+                        <div class="flex items-center justify-between pt-6 border-t border-gray-200">
+                            <a href="{{ route('admin.competition-devices.index') }}" 
+                               class="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-lg text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition duration-200">
+                                キャンセル
+                            </a>
+                            <button type="submit"
+                                    class="inline-flex items-center px-6 py-2 border border-transparent text-sm font-medium rounded-lg shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition duration-200">
+                                <svg class="h-5 w-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+                                </svg>
+                                更新
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </main>
+
+    <script>
+        function selectPlayer() {
+            const select = document.getElementById('player_select');
+            const input = document.getElementById('player_number');
+            if (select.value) {
+                input.value = select.value;
+            }
+        }
+    </script>
+</body>
+</html>

--- a/resources/views/admin/competition-devices/index.blade.php
+++ b/resources/views/admin/competition-devices/index.blade.php
@@ -1,0 +1,249 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>競技端末割り当て - SJT-CP</title>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body class="bg-gray-50 min-h-screen">
+    <!-- ナビゲーションバー -->
+    <nav class="bg-white shadow-lg border-b border-gray-200">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex justify-between h-16">
+                <div class="flex items-center">
+                    <a href="{{ route('admin.home') }}" class="flex items-center">
+                        <div class="h-8 w-8 bg-blue-600 rounded-lg flex items-center justify-center mr-3">
+                            <svg class="h-5 w-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path>
+                            </svg>
+                        </div>
+                        <h1 class="text-xl font-bold text-gray-900">SJT-CP</h1>
+                    </a>
+                    <span class="ml-4 text-gray-400">|</span>
+                    <span class="ml-4 text-gray-600 font-medium">競技端末割り当て</span>
+                </div>
+                <div class="flex items-center space-x-4">
+                    <span class="text-sm text-gray-700">{{ auth()->user()->name }}</span>
+                    <form method="POST" action="{{ route('logout') }}" class="inline">
+                        @csrf
+                        <button type="submit" class="text-sm text-gray-500 hover:text-gray-700">ログアウト</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <!-- メインコンテンツ -->
+    <main class="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
+        <div class="px-4 sm:px-0">
+            <!-- ヘッダー -->
+            <div class="mb-8">
+                <div class="flex items-center justify-between">
+                    <div>
+                        <h2 class="text-3xl font-bold text-gray-900">競技端末割り当て</h2>
+                        <p class="text-gray-600 mt-2">大会ごとの選手用端末割り当てを管理します。</p>
+                    </div>
+                    <div class="flex space-x-3">
+                        <a href="{{ route('admin.competition-devices.export', ['competition_id' => request('competition_id')]) }}" 
+                           class="inline-flex items-center px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+                            <svg class="h-5 w-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
+                            </svg>
+                            CSVエクスポート
+                        </a>
+                        <a href="{{ route('admin.competition-devices.create', ['competition_id' => request('competition_id')]) }}" 
+                           class="inline-flex items-center px-4 py-2 border border-transparent rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+                            <svg class="h-5 w-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+                            </svg>
+                            新規割り当て
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- 検索・フィルター -->
+            <div class="bg-white shadow rounded-lg mb-6">
+                <div class="px-6 py-4">
+                    <form method="GET" action="{{ route('admin.competition-devices.index') }}" class="space-y-4">
+                        <div class="grid grid-cols-1 md:grid-cols-3 gap-4">
+                            <div>
+                                <label for="competition_id" class="block text-sm font-medium text-gray-700">大会</label>
+                                <select id="competition_id" 
+                                        name="competition_id"
+                                        class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
+                                    <option value="">すべての大会</option>
+                                    @foreach($competitions as $competition)
+                                        <option value="{{ $competition->id }}" {{ request('competition_id') == $competition->id ? 'selected' : '' }}>
+                                            {{ $competition->name }}
+                                        </option>
+                                    @endforeach
+                                </select>
+                            </div>
+                            <div>
+                                <label for="search" class="block text-sm font-medium text-gray-700">検索</label>
+                                <input type="text" 
+                                       id="search" 
+                                       name="search" 
+                                       value="{{ request('search') }}"
+                                       placeholder="選手番号、端末名"
+                                       class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
+                            </div>
+                            <div class="flex items-end">
+                                <button type="submit" 
+                                        class="w-full bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                                    検索
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+            <!-- CSVインポート -->
+            @if(request('competition_id'))
+                <div class="bg-white shadow rounded-lg mb-6">
+                    <div class="px-6 py-4">
+                        <h3 class="text-lg font-medium text-gray-900 mb-4">CSVインポート</h3>
+                        <form method="POST" action="{{ route('admin.competition-devices.import') }}" enctype="multipart/form-data" class="flex items-center space-x-4">
+                            @csrf
+                            <input type="hidden" name="competition_id" value="{{ request('competition_id') }}">
+                            <input type="file" 
+                                   name="csv_file" 
+                                   accept=".csv,.txt"
+                                   class="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100">
+                            <button type="submit" 
+                                    class="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500">
+                                インポート
+                            </button>
+                        </form>
+                        <p class="text-xs text-gray-500 mt-2">
+                            形式: 選手番号,端末名
+                        </p>
+                    </div>
+                </div>
+            @endif
+
+            <!-- 成功・エラーメッセージ -->
+            @if(session('success'))
+                <div class="bg-green-50 border border-green-200 rounded-md p-4 mb-6">
+                    <div class="flex">
+                        <div class="flex-shrink-0">
+                            <svg class="h-5 w-5 text-green-400" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
+                            </svg>
+                        </div>
+                        <div class="ml-3">
+                            <p class="text-sm font-medium text-green-800">{{ session('success') }}</p>
+                        </div>
+                    </div>
+                </div>
+            @endif
+
+            @if(session('error'))
+                <div class="bg-red-50 border border-red-200 rounded-md p-4 mb-6">
+                    <div class="flex">
+                        <div class="flex-shrink-0">
+                            <svg class="h-5 w-5 text-red-400" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"></path>
+                            </svg>
+                        </div>
+                        <div class="ml-3">
+                            <p class="text-sm font-medium text-red-800">{{ session('error') }}</p>
+                        </div>
+                    </div>
+                </div>
+            @endif
+
+            <!-- 割り当て一覧テーブル -->
+            <div class="bg-white shadow-xl rounded-xl overflow-hidden">
+                <div class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">大会名</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">選手番号</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">端末名</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">端末種別</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">IPアドレス</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">割り当て日</th>
+                                <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">操作</th>
+                            </tr>
+                        </thead>
+                        <tbody class="bg-white divide-y divide-gray-200">
+                            @forelse($competitionDevices as $competitionDevice)
+                                <tr class="hover:bg-gray-50">
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                                        {{ $competitionDevice->competition->name }}
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap">
+                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800">
+                                            {{ $competitionDevice->player_number }}
+                                        </span>
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap">
+                                        <div class="flex items-center">
+                                            <div class="h-10 w-10 bg-gray-100 rounded-lg flex items-center justify-center mr-3">
+                                                <svg class="h-5 w-5 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
+                                                </svg>
+                                            </div>
+                                            <div>
+                                                <div class="text-sm font-medium text-gray-900">{{ $competitionDevice->device->name }}</div>
+                                            </div>
+                                        </div>
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap">
+                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium 
+                                            @if($competitionDevice->device->type === 'PC') bg-blue-100 text-blue-800
+                                            @elseif($competitionDevice->device->type === 'スマートフォン') bg-green-100 text-green-800
+                                            @else bg-gray-100 text-gray-800 @endif">
+                                            {{ $competitionDevice->device->type }}
+                                        </span>
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 font-mono">
+                                        {{ $competitionDevice->device->ip_address ?? '-' }}
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                        {{ $competitionDevice->created_at->format('Y/m/d') }}
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
+                                        <a href="{{ route('admin.competition-devices.show', $competitionDevice) }}" 
+                                           class="text-blue-600 hover:text-blue-900">詳細</a>
+                                        <a href="{{ route('admin.competition-devices.edit', $competitionDevice) }}" 
+                                           class="text-indigo-600 hover:text-indigo-900">編集</a>
+                                        <form method="POST" action="{{ route('admin.competition-devices.destroy', $competitionDevice) }}" class="inline" 
+                                              onsubmit="return confirm('この割り当てを解除しますか？')">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="text-red-600 hover:text-red-900">解除</button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="7" class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-center">
+                                        @if(request('competition_id'))
+                                            この大会には端末が割り当てられていません。
+                                        @else
+                                            端末の割り当てがありません。
+                                        @endif
+                                    </td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+                
+                <!-- ページネーション -->
+                @if($competitionDevices->hasPages())
+                    <div class="bg-white px-4 py-3 flex items-center justify-between border-t border-gray-200 sm:px-6">
+                        {{ $competitionDevices->links() }}
+                    </div>
+                @endif
+            </div>
+        </div>
+    </main>
+</body>
+</html>

--- a/resources/views/admin/competition-devices/show.blade.php
+++ b/resources/views/admin/competition-devices/show.blade.php
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>端末割り当て詳細 - SJT-CP</title>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body class="bg-gray-50 min-h-screen">
+    <!-- ナビゲーションバー -->
+    <nav class="bg-white shadow-lg border-b border-gray-200">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex justify-between h-16">
+                <div class="flex items-center">
+                    <a href="{{ route('admin.home') }}" class="flex items-center">
+                        <div class="h-8 w-8 bg-blue-600 rounded-lg flex items-center justify-center mr-3">
+                            <svg class="h-5 w-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path>
+                            </svg>
+                        </div>
+                        <h1 class="text-xl font-bold text-gray-900">SJT-CP</h1>
+                    </a>
+                    <span class="ml-4 text-gray-400">|</span>
+                    <a href="{{ route('admin.competition-devices.index') }}" class="ml-4 text-gray-600 hover:text-gray-900">競技端末割り当て</a>
+                    <span class="ml-2 text-gray-400">></span>
+                    <span class="ml-2 text-gray-600 font-medium">詳細</span>
+                </div>
+                <div class="flex items-center space-x-4">
+                    <span class="text-sm text-gray-700">{{ auth()->user()->name }}</span>
+                    <form method="POST" action="{{ route('logout') }}" class="inline">
+                        @csrf
+                        <button type="submit" class="text-sm text-gray-500 hover:text-gray-700">ログアウト</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <!-- メインコンテンツ -->
+    <main class="max-w-4xl mx-auto py-6 sm:px-6 lg:px-8">
+        <div class="px-4 sm:px-0">
+            <!-- ヘッダー -->
+            <div class="mb-8">
+                <div class="flex items-center justify-between">
+                    <div>
+                        <h2 class="text-3xl font-bold text-gray-900">端末割り当て詳細</h2>
+                        <p class="text-gray-600 mt-2">選手番号 {{ $competitionDevice->player_number }} の端末割り当て詳細です。</p>
+                    </div>
+                    <div class="flex space-x-3">
+                        <a href="{{ route('admin.competition-devices.edit', $competitionDevice) }}" 
+                           class="inline-flex items-center px-4 py-2 border border-transparent rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+                            <svg class="h-5 w-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path>
+                            </svg>
+                            編集
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- 大会情報 -->
+            <div class="bg-white shadow-xl rounded-xl overflow-hidden mb-8">
+                <div class="px-6 py-8">
+                    <h3 class="text-lg font-semibold text-gray-900 mb-6">大会情報</h3>
+                    <dl class="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2">
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">大会名</dt>
+                            <dd class="mt-1 text-sm text-gray-900 font-semibold">{{ $competitionDevice->competition->name }}</dd>
+                        </div>
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">開催期間</dt>
+                            <dd class="mt-1 text-sm text-gray-900">{{ $competitionDevice->competition->period }}</dd>
+                        </div>
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">開催場所</dt>
+                            <dd class="mt-1 text-sm text-gray-900">{{ $competitionDevice->competition->venue }}</dd>
+                        </div>
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">競技主査</dt>
+                            <dd class="mt-1 text-sm text-gray-900">{{ $competitionDevice->competition->chief_judge ?? '未設定' }}</dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+
+            <!-- 割り当て情報 -->
+            <div class="bg-white shadow-xl rounded-xl overflow-hidden mb-8">
+                <div class="px-6 py-8">
+                    <h3 class="text-lg font-semibold text-gray-900 mb-6">割り当て情報</h3>
+                    <dl class="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2">
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">選手番号</dt>
+                            <dd class="mt-1">
+                                <span class="inline-flex items-center px-3 py-1 rounded-full text-sm font-medium bg-blue-100 text-blue-800">
+                                    {{ $competitionDevice->player_number }}
+                                </span>
+                            </dd>
+                        </div>
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">割り当て日</dt>
+                            <dd class="mt-1 text-sm text-gray-900">{{ $competitionDevice->created_at->format('Y年m月d日 H:i') }}</dd>
+                        </div>
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">最終更新</dt>
+                            <dd class="mt-1 text-sm text-gray-900">{{ $competitionDevice->updated_at->format('Y年m月d日 H:i') }}</dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+
+            <!-- 端末情報 -->
+            <div class="bg-white shadow-xl rounded-xl overflow-hidden mb-8">
+                <div class="px-6 py-8">
+                    <h3 class="text-lg font-semibold text-gray-900 mb-6">端末情報</h3>
+                    <dl class="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2">
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">端末名</dt>
+                            <dd class="mt-1 text-sm text-gray-900 font-semibold">{{ $competitionDevice->device->name }}</dd>
+                        </div>
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">端末種別</dt>
+                            <dd class="mt-1">
+                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium 
+                                    @if($competitionDevice->device->type === 'PC') bg-blue-100 text-blue-800
+                                    @elseif($competitionDevice->device->type === 'スマートフォン') bg-green-100 text-green-800
+                                    @else bg-gray-100 text-gray-800 @endif">
+                                    {{ $competitionDevice->device->type }}
+                                </span>
+                            </dd>
+                        </div>
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">利用者</dt>
+                            <dd class="mt-1">
+                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-purple-100 text-purple-800">
+                                    {{ $competitionDevice->device->user_type }}
+                                </span>
+                            </dd>
+                        </div>
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">端末登録日</dt>
+                            <dd class="mt-1 text-sm text-gray-900">{{ $competitionDevice->device->created_at->format('Y年m月d日') }}</dd>
+                        </div>
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">IPアドレス</dt>
+                            <dd class="mt-1 text-sm text-gray-900 font-mono">{{ $competitionDevice->device->ip_address ?? '未設定' }}</dd>
+                        </div>
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">MACアドレス</dt>
+                            <dd class="mt-1 text-sm text-gray-900 font-mono">{{ $competitionDevice->device->mac_address ?? '未設定' }}</dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+
+            <!-- 操作ボタン -->
+            <div class="flex items-center justify-between">
+                <a href="{{ route('admin.competition-devices.index') }}" 
+                   class="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-lg text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition duration-200">
+                    <svg class="h-5 w-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
+                    </svg>
+                    一覧に戻る
+                </a>
+                
+                <div class="flex space-x-3">
+                    <a href="{{ route('admin.devices.show', $competitionDevice->device) }}" 
+                       class="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-lg text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition duration-200">
+                        <svg class="h-5 w-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
+                        </svg>
+                        端末詳細
+                    </a>
+                    
+                    <form method="POST" action="{{ route('admin.competition-devices.destroy', $competitionDevice) }}" class="inline" 
+                          onsubmit="return confirm('この割り当てを解除しますか？')">
+                        @csrf
+                        @method('DELETE')
+                        <button type="submit" 
+                                class="inline-flex items-center px-4 py-2 border border-transparent rounded-lg text-sm font-medium text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 transition duration-200">
+                            <svg class="h-5 w-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>
+                            </svg>
+                            割り当て解除
+                        </button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </main>
+</body>
+</html>

--- a/resources/views/admin/devices/create.blade.php
+++ b/resources/views/admin/devices/create.blade.php
@@ -1,0 +1,189 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>端末登録 - SJT-CP</title>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body class="bg-gray-50 min-h-screen">
+    <!-- ナビゲーションバー -->
+    <nav class="bg-white shadow-lg border-b border-gray-200">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex justify-between h-16">
+                <div class="flex items-center">
+                    <a href="{{ route('admin.home') }}" class="flex items-center">
+                        <div class="h-8 w-8 bg-blue-600 rounded-lg flex items-center justify-center mr-3">
+                            <svg class="h-5 w-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path>
+                            </svg>
+                        </div>
+                        <h1 class="text-xl font-bold text-gray-900">SJT-CP</h1>
+                    </a>
+                    <span class="ml-4 text-gray-400">|</span>
+                    <a href="{{ route('admin.devices.index') }}" class="ml-4 text-gray-600 hover:text-gray-900">端末管理</a>
+                    <span class="ml-2 text-gray-400">></span>
+                    <span class="ml-2 text-gray-600 font-medium">新規登録</span>
+                </div>
+                <div class="flex items-center space-x-4">
+                    <span class="text-sm text-gray-700">{{ auth()->user()->name }}</span>
+                    <form method="POST" action="{{ route('logout') }}" class="inline">
+                        @csrf
+                        <button type="submit" class="text-sm text-gray-500 hover:text-gray-700">ログアウト</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <!-- メインコンテンツ -->
+    <main class="max-w-4xl mx-auto py-6 sm:px-6 lg:px-8">
+        <div class="px-4 sm:px-0">
+            <!-- ヘッダー -->
+            <div class="mb-8">
+                <h2 class="text-3xl font-bold text-gray-900">端末登録</h2>
+                <p class="text-gray-600 mt-2">新しい端末を登録してください。</p>
+            </div>
+
+            <!-- エラーメッセージ -->
+            @if($errors->any())
+                <div class="bg-red-50 border border-red-200 rounded-md p-4 mb-6">
+                    <div class="flex">
+                        <div class="flex-shrink-0">
+                            <svg class="h-5 w-5 text-red-400" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"></path>
+                            </svg>
+                        </div>
+                        <div class="ml-3">
+                            <h3 class="text-sm font-medium text-red-800">入力エラーがあります</h3>
+                            <ul class="mt-2 text-sm text-red-700 list-disc list-inside space-y-1">
+                                @foreach($errors->all() as $error)
+                                    <li>{{ $error }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            @endif
+
+            <!-- フォーム -->
+            <div class="bg-white shadow-xl rounded-xl overflow-hidden">
+                <div class="px-6 py-8">
+                    <form method="POST" action="{{ route('admin.devices.store') }}" class="space-y-6">
+                        @csrf
+
+                        <!-- 端末名 -->
+                        <div>
+                            <label for="name" class="block text-sm font-semibold text-gray-700 mb-2">
+                                端末名 <span class="text-red-500">*</span>
+                            </label>
+                            <input type="text" 
+                                   id="name" 
+                                   name="name" 
+                                   value="{{ old('name') }}"
+                                   required
+                                   placeholder="例：PC-001、iPad-A"
+                                   class="block w-full px-3 py-3 border border-gray-300 rounded-lg text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200 sm:text-sm">
+                            @error('name')
+                                <div class="text-red-500 text-sm mt-1">{{ $message }}</div>
+                            @enderror
+                        </div>
+
+                        <!-- 端末種別・利用者 -->
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                            <div>
+                                <label for="type" class="block text-sm font-semibold text-gray-700 mb-2">
+                                    端末種別 <span class="text-red-500">*</span>
+                                </label>
+                                <select id="type" 
+                                        name="type" 
+                                        required
+                                        class="block w-full px-3 py-3 border border-gray-300 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200 sm:text-sm">
+                                    <option value="">選択してください</option>
+                                    @foreach(\App\Models\Device::getTypes() as $key => $value)
+                                        <option value="{{ $key }}" {{ old('type') === $key ? 'selected' : '' }}>{{ $value }}</option>
+                                    @endforeach
+                                </select>
+                                @error('type')
+                                    <div class="text-red-500 text-sm mt-1">{{ $message }}</div>
+                                @enderror
+                            </div>
+
+                            <div>
+                                <label for="user_type" class="block text-sm font-semibold text-gray-700 mb-2">
+                                    利用者 <span class="text-red-500">*</span>
+                                </label>
+                                <select id="user_type" 
+                                        name="user_type" 
+                                        required
+                                        class="block w-full px-3 py-3 border border-gray-300 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200 sm:text-sm">
+                                    <option value="">選択してください</option>
+                                    @foreach(\App\Models\Device::getUserTypes() as $key => $value)
+                                        <option value="{{ $key }}" {{ old('user_type') === $key ? 'selected' : '' }}>{{ $value }}</option>
+                                    @endforeach
+                                </select>
+                                @error('user_type')
+                                    <div class="text-red-500 text-sm mt-1">{{ $message }}</div>
+                                @enderror
+                            </div>
+                        </div>
+
+                        <!-- IPアドレス・MACアドレス -->
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                            <div>
+                                <label for="ip_address" class="block text-sm font-semibold text-gray-700 mb-2">
+                                    IPアドレス (IPv4)
+                                </label>
+                                <input type="text" 
+                                       id="ip_address" 
+                                       name="ip_address" 
+                                       value="{{ old('ip_address') }}"
+                                       placeholder="例：192.168.1.100"
+                                       pattern="^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
+                                       class="block w-full px-3 py-3 border border-gray-300 rounded-lg text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200 sm:text-sm">
+                                @error('ip_address')
+                                    <div class="text-red-500 text-sm mt-1">{{ $message }}</div>
+                                @enderror
+                            </div>
+
+                            <div>
+                                <label for="mac_address" class="block text-sm font-semibold text-gray-700 mb-2">
+                                    MACアドレス
+                                </label>
+                                <input type="text" 
+                                       id="mac_address" 
+                                       name="mac_address" 
+                                       value="{{ old('mac_address') }}"
+                                       placeholder="例：AA:BB:CC:DD:EE:FF"
+                                       pattern="^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$"
+                                       class="block w-full px-3 py-3 border border-gray-300 rounded-lg text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200 sm:text-sm font-mono">
+                                @error('mac_address')
+                                    <div class="text-red-500 text-sm mt-1">{{ $message }}</div>
+                                @enderror
+                                <p class="text-xs text-gray-500 mt-1">
+                                    形式：AA:BB:CC:DD:EE:FF または AA-BB-CC-DD-EE-FF
+                                </p>
+                            </div>
+                        </div>
+
+                        <!-- フォームボタン -->
+                        <div class="flex items-center justify-between pt-6 border-t border-gray-200">
+                            <a href="{{ route('admin.devices.index') }}" 
+                               class="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-lg text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition duration-200">
+                                キャンセル
+                            </a>
+                            <button type="submit"
+                                    class="inline-flex items-center px-6 py-2 border border-transparent text-sm font-medium rounded-lg shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition duration-200">
+                                <svg class="h-5 w-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+                                </svg>
+                                登録
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </main>
+</body>
+</html>

--- a/resources/views/admin/devices/edit.blade.php
+++ b/resources/views/admin/devices/edit.blade.php
@@ -1,0 +1,190 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>端末編集 - SJT-CP</title>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body class="bg-gray-50 min-h-screen">
+    <!-- ナビゲーションバー -->
+    <nav class="bg-white shadow-lg border-b border-gray-200">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex justify-between h-16">
+                <div class="flex items-center">
+                    <a href="{{ route('admin.home') }}" class="flex items-center">
+                        <div class="h-8 w-8 bg-blue-600 rounded-lg flex items-center justify-center mr-3">
+                            <svg class="h-5 w-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path>
+                            </svg>
+                        </div>
+                        <h1 class="text-xl font-bold text-gray-900">SJT-CP</h1>
+                    </a>
+                    <span class="ml-4 text-gray-400">|</span>
+                    <a href="{{ route('admin.devices.index') }}" class="ml-4 text-gray-600 hover:text-gray-900">端末管理</a>
+                    <span class="ml-2 text-gray-400">></span>
+                    <span class="ml-2 text-gray-600 font-medium">{{ $device->name }} 編集</span>
+                </div>
+                <div class="flex items-center space-x-4">
+                    <span class="text-sm text-gray-700">{{ auth()->user()->name }}</span>
+                    <form method="POST" action="{{ route('logout') }}" class="inline">
+                        @csrf
+                        <button type="submit" class="text-sm text-gray-500 hover:text-gray-700">ログアウト</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <!-- メインコンテンツ -->
+    <main class="max-w-4xl mx-auto py-6 sm:px-6 lg:px-8">
+        <div class="px-4 sm:px-0">
+            <!-- ヘッダー -->
+            <div class="mb-8">
+                <h2 class="text-3xl font-bold text-gray-900">端末編集</h2>
+                <p class="text-gray-600 mt-2">{{ $device->name }} の情報を編集してください。</p>
+            </div>
+
+            <!-- エラーメッセージ -->
+            @if($errors->any())
+                <div class="bg-red-50 border border-red-200 rounded-md p-4 mb-6">
+                    <div class="flex">
+                        <div class="flex-shrink-0">
+                            <svg class="h-5 w-5 text-red-400" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"></path>
+                            </svg>
+                        </div>
+                        <div class="ml-3">
+                            <h3 class="text-sm font-medium text-red-800">入力エラーがあります</h3>
+                            <ul class="mt-2 text-sm text-red-700 list-disc list-inside space-y-1">
+                                @foreach($errors->all() as $error)
+                                    <li>{{ $error }}</li>
+                                @endforeach
+                            </ul>
+                        </div>
+                    </div>
+                </div>
+            @endif
+
+            <!-- フォーム -->
+            <div class="bg-white shadow-xl rounded-xl overflow-hidden">
+                <div class="px-6 py-8">
+                    <form method="POST" action="{{ route('admin.devices.update', $device) }}" class="space-y-6">
+                        @csrf
+                        @method('PUT')
+
+                        <!-- 端末名 -->
+                        <div>
+                            <label for="name" class="block text-sm font-semibold text-gray-700 mb-2">
+                                端末名 <span class="text-red-500">*</span>
+                            </label>
+                            <input type="text" 
+                                   id="name" 
+                                   name="name" 
+                                   value="{{ old('name', $device->name) }}"
+                                   required
+                                   placeholder="例：PC-001、iPad-A"
+                                   class="block w-full px-3 py-3 border border-gray-300 rounded-lg text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200 sm:text-sm">
+                            @error('name')
+                                <div class="text-red-500 text-sm mt-1">{{ $message }}</div>
+                            @enderror
+                        </div>
+
+                        <!-- 端末種別・利用者 -->
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                            <div>
+                                <label for="type" class="block text-sm font-semibold text-gray-700 mb-2">
+                                    端末種別 <span class="text-red-500">*</span>
+                                </label>
+                                <select id="type" 
+                                        name="type" 
+                                        required
+                                        class="block w-full px-3 py-3 border border-gray-300 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200 sm:text-sm">
+                                    <option value="">選択してください</option>
+                                    @foreach(\App\Models\Device::getTypes() as $key => $value)
+                                        <option value="{{ $key }}" {{ old('type', $device->type) === $key ? 'selected' : '' }}>{{ $value }}</option>
+                                    @endforeach
+                                </select>
+                                @error('type')
+                                    <div class="text-red-500 text-sm mt-1">{{ $message }}</div>
+                                @enderror
+                            </div>
+
+                            <div>
+                                <label for="user_type" class="block text-sm font-semibold text-gray-700 mb-2">
+                                    利用者 <span class="text-red-500">*</span>
+                                </label>
+                                <select id="user_type" 
+                                        name="user_type" 
+                                        required
+                                        class="block w-full px-3 py-3 border border-gray-300 rounded-lg text-gray-900 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200 sm:text-sm">
+                                    <option value="">選択してください</option>
+                                    @foreach(\App\Models\Device::getUserTypes() as $key => $value)
+                                        <option value="{{ $key }}" {{ old('user_type', $device->user_type) === $key ? 'selected' : '' }}>{{ $value }}</option>
+                                    @endforeach
+                                </select>
+                                @error('user_type')
+                                    <div class="text-red-500 text-sm mt-1">{{ $message }}</div>
+                                @enderror
+                            </div>
+                        </div>
+
+                        <!-- IPアドレス・MACアドレス -->
+                        <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+                            <div>
+                                <label for="ip_address" class="block text-sm font-semibold text-gray-700 mb-2">
+                                    IPアドレス (IPv4)
+                                </label>
+                                <input type="text" 
+                                       id="ip_address" 
+                                       name="ip_address" 
+                                       value="{{ old('ip_address', $device->ip_address) }}"
+                                       placeholder="例：192.168.1.100"
+                                       pattern="^(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)$"
+                                       class="block w-full px-3 py-3 border border-gray-300 rounded-lg text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200 sm:text-sm">
+                                @error('ip_address')
+                                    <div class="text-red-500 text-sm mt-1">{{ $message }}</div>
+                                @enderror
+                            </div>
+
+                            <div>
+                                <label for="mac_address" class="block text-sm font-semibold text-gray-700 mb-2">
+                                    MACアドレス
+                                </label>
+                                <input type="text" 
+                                       id="mac_address" 
+                                       name="mac_address" 
+                                       value="{{ old('mac_address', $device->mac_address) }}"
+                                       placeholder="例：AA:BB:CC:DD:EE:FF"
+                                       pattern="^([0-9A-Fa-f]{2}[:-]){5}([0-9A-Fa-f]{2})$"
+                                       class="block w-full px-3 py-3 border border-gray-300 rounded-lg text-gray-900 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent transition duration-200 sm:text-sm font-mono">
+                                @error('mac_address')
+                                    <div class="text-red-500 text-sm mt-1">{{ $message }}</div>
+                                @enderror
+                                <p class="text-xs text-gray-500 mt-1">
+                                    形式：AA:BB:CC:DD:EE:FF または AA-BB-CC-DD-EE-FF
+                                </p>
+                            </div>
+                        </div>
+
+                        <!-- フォームボタン -->
+                        <div class="flex items-center justify-between pt-6 border-t border-gray-200">
+                            <a href="{{ route('admin.devices.index') }}" 
+                               class="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-lg text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition duration-200">
+                                キャンセル
+                            </a>
+                            <button type="submit"
+                                    class="inline-flex items-center px-6 py-2 border border-transparent text-sm font-medium rounded-lg shadow-sm text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition duration-200">
+                                <svg class="h-5 w-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
+                                </svg>
+                                更新
+                            </button>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </main>
+</body>
+</html>

--- a/resources/views/admin/devices/index.blade.php
+++ b/resources/views/admin/devices/index.blade.php
@@ -1,0 +1,254 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>端末一覧 - SJT-CP</title>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body class="bg-gray-50 min-h-screen">
+    <!-- ナビゲーションバー -->
+    <nav class="bg-white shadow-lg border-b border-gray-200">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex justify-between h-16">
+                <div class="flex items-center">
+                    <a href="{{ route('admin.home') }}" class="flex items-center">
+                        <div class="h-8 w-8 bg-blue-600 rounded-lg flex items-center justify-center mr-3">
+                            <svg class="h-5 w-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path>
+                            </svg>
+                        </div>
+                        <h1 class="text-xl font-bold text-gray-900">SJT-CP</h1>
+                    </a>
+                    <span class="ml-4 text-gray-400">|</span>
+                    <span class="ml-4 text-gray-600 font-medium">端末管理</span>
+                </div>
+                <div class="flex items-center space-x-4">
+                    <span class="text-sm text-gray-700">{{ auth()->user()->name }}</span>
+                    <form method="POST" action="{{ route('logout') }}" class="inline">
+                        @csrf
+                        <button type="submit" class="text-sm text-gray-500 hover:text-gray-700">ログアウト</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <!-- メインコンテンツ -->
+    <main class="max-w-7xl mx-auto py-6 sm:px-6 lg:px-8">
+        <div class="px-4 sm:px-0">
+            <!-- ヘッダー -->
+            <div class="mb-8">
+                <div class="flex items-center justify-between">
+                    <div>
+                        <h2 class="text-3xl font-bold text-gray-900">端末一覧</h2>
+                        <p class="text-gray-600 mt-2">システムで管理している端末の一覧です。</p>
+                    </div>
+                    <div class="flex space-x-3">
+                        <a href="{{ route('admin.devices.export') }}" 
+                           class="inline-flex items-center px-4 py-2 border border-gray-300 rounded-lg text-sm font-medium text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+                            <svg class="h-5 w-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
+                            </svg>
+                            CSVエクスポート
+                        </a>
+                        <a href="{{ route('admin.devices.create') }}" 
+                           class="inline-flex items-center px-4 py-2 border border-transparent rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+                            <svg class="h-5 w-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 6v6m0 0v6m0-6h6m-6 0H6"></path>
+                            </svg>
+                            新規登録
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- 検索・フィルター -->
+            <div class="bg-white shadow rounded-lg mb-6">
+                <div class="px-6 py-4">
+                    <form method="GET" action="{{ route('admin.devices.index') }}" class="space-y-4">
+                        <div class="grid grid-cols-1 md:grid-cols-4 gap-4">
+                            <div>
+                                <label for="search" class="block text-sm font-medium text-gray-700">検索</label>
+                                <input type="text" 
+                                       id="search" 
+                                       name="search" 
+                                       value="{{ request('search') }}"
+                                       placeholder="端末名、IPアドレス、MACアドレス"
+                                       class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
+                            </div>
+                            <div>
+                                <label for="type" class="block text-sm font-medium text-gray-700">端末種別</label>
+                                <select id="type" 
+                                        name="type"
+                                        class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
+                                    <option value="">すべて</option>
+                                    @foreach(\App\Models\Device::getTypes() as $key => $value)
+                                        <option value="{{ $key }}" {{ request('type') === $key ? 'selected' : '' }}>{{ $value }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                            <div>
+                                <label for="user_type" class="block text-sm font-medium text-gray-700">利用者</label>
+                                <select id="user_type" 
+                                        name="user_type"
+                                        class="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 sm:text-sm">
+                                    <option value="">すべて</option>
+                                    @foreach(\App\Models\Device::getUserTypes() as $key => $value)
+                                        <option value="{{ $key }}" {{ request('user_type') === $key ? 'selected' : '' }}>{{ $value }}</option>
+                                    @endforeach
+                                </select>
+                            </div>
+                            <div class="flex items-end">
+                                <button type="submit" 
+                                        class="w-full bg-blue-600 text-white px-4 py-2 rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500">
+                                    検索
+                                </button>
+                            </div>
+                        </div>
+                    </form>
+                </div>
+            </div>
+
+            <!-- CSVインポート -->
+            <div class="bg-white shadow rounded-lg mb-6">
+                <div class="px-6 py-4">
+                    <h3 class="text-lg font-medium text-gray-900 mb-4">CSVインポート</h3>
+                    <form method="POST" action="{{ route('admin.devices.import') }}" enctype="multipart/form-data" class="flex items-center space-x-4">
+                        @csrf
+                        <input type="file" 
+                               name="csv_file" 
+                               accept=".csv,.txt"
+                               class="block w-full text-sm text-gray-500 file:mr-4 file:py-2 file:px-4 file:rounded-full file:border-0 file:text-sm file:font-semibold file:bg-blue-50 file:text-blue-700 hover:file:bg-blue-100">
+                        <button type="submit" 
+                                class="px-4 py-2 bg-green-600 text-white rounded-md hover:bg-green-700 focus:outline-none focus:ring-2 focus:ring-green-500">
+                            インポート
+                        </button>
+                    </form>
+                    <p class="text-xs text-gray-500 mt-2">
+                        形式: 端末名,端末種別,利用者,IPアドレス,MACアドレス
+                    </p>
+                </div>
+            </div>
+
+            <!-- 成功・エラーメッセージ -->
+            @if(session('success'))
+                <div class="bg-green-50 border border-green-200 rounded-md p-4 mb-6">
+                    <div class="flex">
+                        <div class="flex-shrink-0">
+                            <svg class="h-5 w-5 text-green-400" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 1.414l2 2a1 1 0 001.414 0l4-4z" clip-rule="evenodd"></path>
+                            </svg>
+                        </div>
+                        <div class="ml-3">
+                            <p class="text-sm font-medium text-green-800">{{ session('success') }}</p>
+                        </div>
+                    </div>
+                </div>
+            @endif
+
+            @if(session('error'))
+                <div class="bg-red-50 border border-red-200 rounded-md p-4 mb-6">
+                    <div class="flex">
+                        <div class="flex-shrink-0">
+                            <svg class="h-5 w-5 text-red-400" fill="currentColor" viewBox="0 0 20 20">
+                                <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd"></path>
+                            </svg>
+                        </div>
+                        <div class="ml-3">
+                            <p class="text-sm font-medium text-red-800">{{ session('error') }}</p>
+                        </div>
+                    </div>
+                </div>
+            @endif
+
+            <!-- 端末一覧テーブル -->
+            <div class="bg-white shadow-xl rounded-xl overflow-hidden">
+                <div class="overflow-x-auto">
+                    <table class="min-w-full divide-y divide-gray-200">
+                        <thead class="bg-gray-50">
+                            <tr>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">端末名</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">端末種別</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">利用者</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">IPアドレス</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">MACアドレス</th>
+                                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">登録日</th>
+                                <th class="px-6 py-3 text-right text-xs font-medium text-gray-500 uppercase tracking-wider">操作</th>
+                            </tr>
+                        </thead>
+                        <tbody class="bg-white divide-y divide-gray-200">
+                            @forelse($devices as $device)
+                                <tr class="hover:bg-gray-50">
+                                    <td class="px-6 py-4 whitespace-nowrap">
+                                        <div class="flex items-center">
+                                            <div class="h-10 w-10 bg-gray-100 rounded-lg flex items-center justify-center mr-3">
+                                                <svg class="h-5 w-5 text-gray-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
+                                                </svg>
+                                            </div>
+                                            <div>
+                                                <div class="text-sm font-medium text-gray-900">{{ $device->name }}</div>
+                                            </div>
+                                        </div>
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap">
+                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium 
+                                            @if($device->type === 'PC') bg-blue-100 text-blue-800
+                                            @elseif($device->type === 'スマートフォン') bg-green-100 text-green-800
+                                            @else bg-gray-100 text-gray-800 @endif">
+                                            {{ $device->type }}
+                                        </span>
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap">
+                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium 
+                                            @if($device->user_type === '選手') bg-purple-100 text-purple-800
+                                            @elseif($device->user_type === '競技関係者') bg-yellow-100 text-yellow-800
+                                            @else bg-gray-100 text-gray-800 @endif">
+                                            {{ $device->user_type }}
+                                        </span>
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                        {{ $device->ip_address ?? '-' }}
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900 font-mono">
+                                        {{ $device->mac_address ?? '-' }}
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-500">
+                                        {{ $device->created_at->format('Y/m/d') }}
+                                    </td>
+                                    <td class="px-6 py-4 whitespace-nowrap text-right text-sm font-medium space-x-2">
+                                        <a href="{{ route('admin.devices.show', $device) }}" 
+                                           class="text-blue-600 hover:text-blue-900">詳細</a>
+                                        <a href="{{ route('admin.devices.edit', $device) }}" 
+                                           class="text-indigo-600 hover:text-indigo-900">編集</a>
+                                        <form method="POST" action="{{ route('admin.devices.destroy', $device) }}" class="inline" 
+                                              onsubmit="return confirm('この端末を削除しますか？')">
+                                            @csrf
+                                            @method('DELETE')
+                                            <button type="submit" class="text-red-600 hover:text-red-900">削除</button>
+                                        </form>
+                                    </td>
+                                </tr>
+                            @empty
+                                <tr>
+                                    <td colspan="7" class="px-6 py-4 whitespace-nowrap text-sm text-gray-500 text-center">
+                                        端末が登録されていません。
+                                    </td>
+                                </tr>
+                            @endforelse
+                        </tbody>
+                    </table>
+                </div>
+                
+                <!-- ページネーション -->
+                @if($devices->hasPages())
+                    <div class="bg-white px-4 py-3 flex items-center justify-between border-t border-gray-200 sm:px-6">
+                        {{ $devices->links() }}
+                    </div>
+                @endif
+            </div>
+        </div>
+    </main>
+</body>
+</html>

--- a/resources/views/admin/devices/show.blade.php
+++ b/resources/views/admin/devices/show.blade.php
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>端末詳細 - SJT-CP</title>
+    @vite(['resources/css/app.css', 'resources/js/app.js'])
+</head>
+<body class="bg-gray-50 min-h-screen">
+    <!-- ナビゲーションバー -->
+    <nav class="bg-white shadow-lg border-b border-gray-200">
+        <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+            <div class="flex justify-between h-16">
+                <div class="flex items-center">
+                    <a href="{{ route('admin.home') }}" class="flex items-center">
+                        <div class="h-8 w-8 bg-blue-600 rounded-lg flex items-center justify-center mr-3">
+                            <svg class="h-5 w-5 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z"></path>
+                            </svg>
+                        </div>
+                        <h1 class="text-xl font-bold text-gray-900">SJT-CP</h1>
+                    </a>
+                    <span class="ml-4 text-gray-400">|</span>
+                    <a href="{{ route('admin.devices.index') }}" class="ml-4 text-gray-600 hover:text-gray-900">端末管理</a>
+                    <span class="ml-2 text-gray-400">></span>
+                    <span class="ml-2 text-gray-600 font-medium">{{ $device->name }}</span>
+                </div>
+                <div class="flex items-center space-x-4">
+                    <span class="text-sm text-gray-700">{{ auth()->user()->name }}</span>
+                    <form method="POST" action="{{ route('logout') }}" class="inline">
+                        @csrf
+                        <button type="submit" class="text-sm text-gray-500 hover:text-gray-700">ログアウト</button>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </nav>
+
+    <!-- メインコンテンツ -->
+    <main class="max-w-4xl mx-auto py-6 sm:px-6 lg:px-8">
+        <div class="px-4 sm:px-0">
+            <!-- ヘッダー -->
+            <div class="mb-8">
+                <div class="flex items-center justify-between">
+                    <div>
+                        <h2 class="text-3xl font-bold text-gray-900">端末詳細</h2>
+                        <p class="text-gray-600 mt-2">{{ $device->name }} の詳細情報です。</p>
+                    </div>
+                    <div class="flex space-x-3">
+                        <a href="{{ route('admin.devices.edit', $device) }}" 
+                           class="inline-flex items-center px-4 py-2 border border-transparent rounded-lg text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500">
+                            <svg class="h-5 w-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path>
+                            </svg>
+                            編集
+                        </a>
+                    </div>
+                </div>
+            </div>
+
+            <!-- 端末情報 -->
+            <div class="bg-white shadow-xl rounded-xl overflow-hidden mb-8">
+                <div class="px-6 py-8">
+                    <h3 class="text-lg font-semibold text-gray-900 mb-6">基本情報</h3>
+                    <dl class="grid grid-cols-1 gap-x-4 gap-y-6 sm:grid-cols-2">
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">端末名</dt>
+                            <dd class="mt-1 text-sm text-gray-900 font-semibold">{{ $device->name }}</dd>
+                        </div>
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">端末種別</dt>
+                            <dd class="mt-1">
+                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium 
+                                    @if($device->type === 'PC') bg-blue-100 text-blue-800
+                                    @elseif($device->type === 'スマートフォン') bg-green-100 text-green-800
+                                    @else bg-gray-100 text-gray-800 @endif">
+                                    {{ $device->type }}
+                                </span>
+                            </dd>
+                        </div>
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">利用者</dt>
+                            <dd class="mt-1">
+                                <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium 
+                                    @if($device->user_type === '選手') bg-purple-100 text-purple-800
+                                    @elseif($device->user_type === '競技関係者') bg-yellow-100 text-yellow-800
+                                    @else bg-gray-100 text-gray-800 @endif">
+                                    {{ $device->user_type }}
+                                </span>
+                            </dd>
+                        </div>
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">登録日</dt>
+                            <dd class="mt-1 text-sm text-gray-900">{{ $device->created_at->format('Y年m月d日 H:i') }}</dd>
+                        </div>
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">IPアドレス</dt>
+                            <dd class="mt-1 text-sm text-gray-900 font-mono">{{ $device->ip_address ?? '未設定' }}</dd>
+                        </div>
+                        <div>
+                            <dt class="text-sm font-medium text-gray-500">MACアドレス</dt>
+                            <dd class="mt-1 text-sm text-gray-900 font-mono">{{ $device->mac_address ?? '未設定' }}</dd>
+                        </div>
+                    </dl>
+                </div>
+            </div>
+
+            <!-- 大会割り当て履歴 -->
+            @if($device->user_type === '選手' && $device->competitions->count() > 0)
+                <div class="bg-white shadow-xl rounded-xl overflow-hidden">
+                    <div class="px-6 py-8">
+                        <h3 class="text-lg font-semibold text-gray-900 mb-6">大会割り当て履歴</h3>
+                        <div class="overflow-x-auto">
+                            <table class="min-w-full divide-y divide-gray-200">
+                                <thead class="bg-gray-50">
+                                    <tr>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">大会名</th>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">選手番号</th>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">開催期間</th>
+                                        <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">開催場所</th>
+                                    </tr>
+                                </thead>
+                                <tbody class="bg-white divide-y divide-gray-200">
+                                    @foreach($device->competitions as $competition)
+                                        <tr class="hover:bg-gray-50">
+                                            <td class="px-6 py-4 whitespace-nowrap text-sm font-medium text-gray-900">
+                                                {{ $competition->name }}
+                                            </td>
+                                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                                {{ $competition->pivot->player_number }}
+                                            </td>
+                                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                                {{ $competition->period }}
+                                            </td>
+                                            <td class="px-6 py-4 whitespace-nowrap text-sm text-gray-900">
+                                                {{ $competition->venue }}
+                                            </td>
+                                        </tr>
+                                    @endforeach
+                                </tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            @elseif($device->user_type === '選手')
+                <div class="bg-white shadow-xl rounded-xl overflow-hidden">
+                    <div class="px-6 py-8 text-center">
+                        <svg class="mx-auto h-12 w-12 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v10a2 2 0 002 2h8a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2"></path>
+                        </svg>
+                        <h3 class="mt-2 text-sm font-medium text-gray-900">大会割り当てなし</h3>
+                        <p class="mt-1 text-sm text-gray-500">この端末はまだ大会に割り当てられていません。</p>
+                    </div>
+                </div>
+            @endif
+
+            <!-- 戻るボタン -->
+            <div class="mt-8">
+                <a href="{{ route('admin.devices.index') }}" 
+                   class="inline-flex items-center px-4 py-2 border border-gray-300 shadow-sm text-sm font-medium rounded-lg text-gray-700 bg-white hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 transition duration-200">
+                    <svg class="h-5 w-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 19l-7-7m0 0l7-7m-7 7h18"></path>
+                    </svg>
+                    端末一覧に戻る
+                </a>
+            </div>
+        </div>
+    </main>
+</body>
+</html>

--- a/resources/views/admin/home.blade.php
+++ b/resources/views/admin/home.blade.php
@@ -139,6 +139,32 @@
                     </div>
                 </a>
 
+                <!-- 端末管理 -->
+                <a href="{{ route('admin.devices.index') }}" class="block bg-white overflow-hidden shadow-lg rounded-xl hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1">
+                    <div class="p-6">
+                        <div class="flex items-center">
+                            <div class="flex-shrink-0">
+                                <div class="h-12 w-12 bg-orange-100 rounded-lg flex items-center justify-center">
+                                    <svg class="h-6 w-6 text-orange-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9.75 17L9 20l-1 1h8l-1-1-.75-3M3 13h18M5 17h14a2 2 0 002-2V5a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"></path>
+                                    </svg>
+                                </div>
+                            </div>
+                            <div class="ml-4">
+                                <h3 class="text-lg font-semibold text-gray-900">端末管理</h3>
+                                <p class="text-sm text-gray-600">端末情報と大会割り当てを管理</p>
+                            </div>
+                        </div>
+                        <div class="mt-4">
+                            <div class="flex items-center justify-between">
+                                <span class="text-orange-600 text-sm font-medium">
+                                    開く →
+                                </span>
+                            </div>
+                        </div>
+                    </div>
+                </a>
+
                 <!-- システム管理 -->
                 <div class="bg-white overflow-hidden shadow-lg rounded-xl opacity-75 cursor-not-allowed">
                     <div class="p-6">

--- a/resources/views/admin/home.blade.php
+++ b/resources/views/admin/home.blade.php
@@ -114,9 +114,9 @@
                 </a>
 
                 <!-- 選手情報管理 -->
-                <a href="{{ route('admin.players.index') }}" class="block bg-white overflow-hidden shadow-lg rounded-xl hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1">
+                <div class="bg-white overflow-hidden shadow-lg rounded-xl hover:shadow-xl transition-all duration-300">
                     <div class="p-6">
-                        <div class="flex items-center">
+                        <div class="flex items-center mb-4">
                             <div class="flex-shrink-0">
                                 <div class="h-12 w-12 bg-green-100 rounded-lg flex items-center justify-center">
                                     <svg class="h-6 w-6 text-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -129,15 +129,24 @@
                                 <p class="text-sm text-gray-600">選手の情報を管理</p>
                             </div>
                         </div>
-                        <div class="mt-4">
-                            <div class="flex items-center justify-between">
-                                <span class="text-green-600 text-sm font-medium">
-                                    開く →
-                                </span>
-                            </div>
+                        
+                        <!-- サブメニュー -->
+                        <div class="space-y-2">
+                            <a href="{{ route('admin.players.index') }}" 
+                               class="block w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-green-50 hover:text-green-800 rounded-md transition-colors duration-200">
+                                選手一覧
+                            </a>
+                            <a href="{{ route('admin.competition-players.index') }}" 
+                               class="block w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-green-50 hover:text-green-800 rounded-md transition-colors duration-200">
+                                大会選手管理
+                            </a>
+                            <a href="{{ route('admin.competition-devices.index') }}" 
+                               class="block w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-green-50 hover:text-green-800 rounded-md transition-colors duration-200">
+                                競技端末割り当て
+                            </a>
                         </div>
                     </div>
-                </a>
+                </div>
 
                 <!-- 端末管理 -->
                 <a href="{{ route('admin.devices.index') }}" class="block bg-white overflow-hidden shadow-lg rounded-xl hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1">

--- a/resources/views/admin/home.blade.php
+++ b/resources/views/admin/home.blade.php
@@ -140,18 +140,14 @@
                                class="block w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-green-50 hover:text-green-800 rounded-md transition-colors duration-200">
                                 大会選手管理
                             </a>
-                            <a href="{{ route('admin.competition-devices.index') }}" 
-                               class="block w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-green-50 hover:text-green-800 rounded-md transition-colors duration-200">
-                                競技端末割り当て
-                            </a>
                         </div>
                     </div>
                 </div>
 
                 <!-- 端末管理 -->
-                <a href="{{ route('admin.devices.index') }}" class="block bg-white overflow-hidden shadow-lg rounded-xl hover:shadow-xl transition-all duration-300 transform hover:-translate-y-1">
+                <div class="bg-white overflow-hidden shadow-lg rounded-xl hover:shadow-xl transition-all duration-300">
                     <div class="p-6">
-                        <div class="flex items-center">
+                        <div class="flex items-center mb-4">
                             <div class="flex-shrink-0">
                                 <div class="h-12 w-12 bg-orange-100 rounded-lg flex items-center justify-center">
                                     <svg class="h-6 w-6 text-orange-600" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -164,15 +160,20 @@
                                 <p class="text-sm text-gray-600">端末情報と大会割り当てを管理</p>
                             </div>
                         </div>
-                        <div class="mt-4">
-                            <div class="flex items-center justify-between">
-                                <span class="text-orange-600 text-sm font-medium">
-                                    開く →
-                                </span>
-                            </div>
+                        
+                        <!-- サブメニュー -->
+                        <div class="space-y-2">
+                            <a href="{{ route('admin.devices.index') }}" 
+                               class="block w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-orange-50 hover:text-orange-800 rounded-md transition-colors duration-200">
+                                端末一覧
+                            </a>
+                            <a href="{{ route('admin.competition-devices.index') }}" 
+                               class="block w-full text-left px-3 py-2 text-sm text-gray-700 hover:bg-orange-50 hover:text-orange-800 rounded-md transition-colors duration-200">
+                                競技端末割り当て
+                            </a>
                         </div>
                     </div>
-                </a>
+                </div>
 
                 <!-- システム管理 -->
                 <div class="bg-white overflow-hidden shadow-lg rounded-xl opacity-75 cursor-not-allowed">

--- a/routes/web.php
+++ b/routes/web.php
@@ -47,28 +47,28 @@ Route::middleware('auth')->prefix('admin')->name('admin.')->group(function () {
         ->name('competition-schedules.import');
     
     // 選手管理
-    Route::resource('players', PlayerController::class);
     Route::get('players/export', [PlayerController::class, 'export'])->name('players.export');
     Route::post('players/import', [PlayerController::class, 'import'])->name('players.import');
+    Route::resource('players', PlayerController::class);
     
     // 大会選手割り当て管理
-    Route::resource('competition-players', CompetitionPlayerController::class);
     Route::get('competition-players/export', [CompetitionPlayerController::class, 'export'])->name('competition-players.export');
     Route::post('competition-players/import', [CompetitionPlayerController::class, 'import'])->name('competition-players.import');
     Route::post('competition-players/generate-player-numbers', [CompetitionPlayerController::class, 'generatePlayerNumbers'])
         ->name('competition-players.generate-player-numbers');
+    Route::resource('competition-players', CompetitionPlayerController::class);
     
     // 端末管理
-    Route::resource('devices', DeviceController::class);
     Route::get('devices/export', [DeviceController::class, 'export'])->name('devices.export');
     Route::post('devices/import', [DeviceController::class, 'import'])->name('devices.import');
+    Route::resource('devices', DeviceController::class);
     
     // 競技端末割り当て管理
-    Route::resource('competition-devices', CompetitionDeviceController::class);
     Route::get('competition-devices/export', [CompetitionDeviceController::class, 'export'])->name('competition-devices.export');
     Route::post('competition-devices/import', [CompetitionDeviceController::class, 'import'])->name('competition-devices.import');
     Route::get('api/competition-devices/player-numbers', [CompetitionDeviceController::class, 'getAvailablePlayerNumbers'])
         ->name('api.competition-devices.player-numbers');
+    Route::resource('competition-devices', CompetitionDeviceController::class);
 });
 
 // ルートアクセス時のリダイレクト

--- a/routes/web.php
+++ b/routes/web.php
@@ -8,6 +8,8 @@ use App\Http\Controllers\Admin\CompetitionDayController;
 use App\Http\Controllers\Admin\CompetitionScheduleController;
 use App\Http\Controllers\Admin\PlayerController;
 use App\Http\Controllers\Admin\CompetitionPlayerController;
+use App\Http\Controllers\Admin\DeviceController;
+use App\Http\Controllers\Admin\CompetitionDeviceController;
 
 // 認証系ルート
 Route::get('/login', [LoginController::class, 'showLoginForm'])->name('login');
@@ -55,6 +57,18 @@ Route::middleware('auth')->prefix('admin')->name('admin.')->group(function () {
     Route::post('competition-players/import', [CompetitionPlayerController::class, 'import'])->name('competition-players.import');
     Route::post('competition-players/generate-player-numbers', [CompetitionPlayerController::class, 'generatePlayerNumbers'])
         ->name('competition-players.generate-player-numbers');
+    
+    // 端末管理
+    Route::resource('devices', DeviceController::class);
+    Route::get('devices/export', [DeviceController::class, 'export'])->name('devices.export');
+    Route::post('devices/import', [DeviceController::class, 'import'])->name('devices.import');
+    
+    // 競技端末割り当て管理
+    Route::resource('competition-devices', CompetitionDeviceController::class);
+    Route::get('competition-devices/export', [CompetitionDeviceController::class, 'export'])->name('competition-devices.export');
+    Route::post('competition-devices/import', [CompetitionDeviceController::class, 'import'])->name('competition-devices.import');
+    Route::get('api/competition-devices/player-numbers', [CompetitionDeviceController::class, 'getAvailablePlayerNumbers'])
+        ->name('api.competition-devices.player-numbers');
 });
 
 // ルートアクセス時のリダイレクト


### PR DESCRIPTION
## 概要
端末管理機能を完全実装し、以下の機能を追加しました：

## 主な機能
### 端末一覧管理
- ✅ 端末の登録・編集・削除・詳細表示
- ✅ 端末種別（PC、スマートフォン、その他）
- ✅ 利用者種別（選手、競技関係者、ネットワーク）
- ✅ IPアドレス・MACアドレス管理
- ✅ 検索・フィルター機能
- ✅ CSVインポート・エクスポート機能

### 競技端末割り当て管理
- ✅ 大会ごとの選手用端末割り当て
- ✅ 選手番号との紐づけ
- ✅ 参加選手からの自動候補表示
- ✅ 重複チェック機能
- ✅ 検索・フィルター機能
- ✅ CSVインポート・エクスポート機能

## UI/UX改善
- ✅ 管理画面ホームにサブメニュー追加
- ✅ 端末管理：「端末一覧」「競技端末割り当て」
- ✅ レスポンシブデザイン対応
- ✅ 直感的なユーザーインターフェース

## 技術的改善
- ✅ ルート順序の最適化（export/importルートの404エラー修正）
- ✅ CSVエクスポートを選手管理と統一された方式に変更
- ✅ エラーハンドリングの強化
- ✅ バリデーション機能の実装

## データベース
- ✅ `devices`テーブル
- ✅ `competition_devices`テーブル
- ✅ 適切なリレーションシップとインデックス

## テスト済み機能
- ✅ 全CRUD操作
- ✅ CSVインポート・エクスポート
- ✅ 検索・フィルター
- ✅ バリデーション・エラーハンドリング

🤖 Generated with [Claude Code](https://claude.ai/code)