### PR TITLE
APIをサブドメインで提供する機能を実装

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,7 @@ APP_ENV=local
 APP_KEY=
 APP_DEBUG=true
 APP_URL=http://localhost
+API_DOMAIN=api.localhost
 
 APP_LOCALE=en
 APP_FALLBACK_LOCALE=en

--- a/README_SJT_CP.md
+++ b/README_SJT_CP.md
@@ -1,0 +1,45 @@
+# SJT-CP (SkillJapan Tools Control Panel)
+
+## 概要
+技能競技会のウェブデザイン職種の競技運営サポート用コントロールパネルです。
+
+## ローカル開発環境のセットアップ
+
+### APIサブドメインの設定
+
+APIはサブドメイン（`api.localhost`）で提供されるため、ローカル開発環境では以下の設定が必要です。
+
+#### macOS/Linuxの場合
+
+1. `/etc/hosts`ファイルを編集します:
+```bash
+sudo nano /etc/hosts
+```
+
+2. 以下の行を追加します:
+```
+127.0.0.1   api.localhost
+```
+
+3. ファイルを保存して閉じます（Ctrl+X → Y → Enter）
+
+#### Windowsの場合
+
+1. 管理者権限でメモ帳を開きます
+2. `C:\Windows\System32\drivers\etc\hosts`ファイルを開きます
+3. 以下の行を追加します:
+```
+127.0.0.1   api.localhost
+```
+4. ファイルを保存します
+
+### 動作確認
+
+設定後、以下のURLでアクセスできるようになります：
+- メインアプリケーション: `http://localhost`
+- API: `http://api.localhost`
+
+### 注意事項
+
+- Laravel Sailを使用している場合は、Dockerコンテナ内でもhostsの設定が必要な場合があります
+- 本番環境では、実際のDNSレコードでサブドメインを設定してください

--- a/app/Helpers/ApiHelper.php
+++ b/app/Helpers/ApiHelper.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Helpers;
+
+class ApiHelper
+{
+    /**
+     * APIのベースURLを取得
+     *
+     * @return string
+     */
+    public static function baseUrl(): string
+    {
+        $apiDomain = config('app.api_domain');
+        $scheme = parse_url(config('app.url'), PHP_URL_SCHEME) ?? 'http';
+        
+        return $scheme . '://' . $apiDomain;
+    }
+
+    /**
+     * APIのURLを生成
+     *
+     * @param string $path
+     * @return string
+     */
+    public static function url(string $path): string
+    {
+        $path = ltrim($path, '/');
+        return self::baseUrl() . '/' . $path;
+    }
+}

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,13 +3,21 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Support\Facades\Route;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
         web: __DIR__.'/../routes/web.php',
-        api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
         health: '/up',
+        using: function () {
+            Route::middleware('api')
+                ->domain(config('app.api_domain'))
+                ->group(base_path('routes/api.php'));
+            
+            Route::middleware('web')
+                ->group(base_path('routes/web.php'));
+        },
     )
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->alias([

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,10 @@
             "App\\": "app/",
             "Database\\Factories\\": "database/factories/",
             "Database\\Seeders\\": "database/seeders/"
-        }
+        },
+        "files": [
+            "app/Helpers/ApiHelper.php"
+        ]
     },
     "autoload-dev": {
         "psr-4": {

--- a/config/app.php
+++ b/config/app.php
@@ -54,6 +54,8 @@ return [
 
     'url' => env('APP_URL', 'http://localhost'),
 
+    'api_domain' => env('API_DOMAIN', 'api.localhost'),
+
     /*
     |--------------------------------------------------------------------------
     | Application Timezone

--- a/config/cors.php
+++ b/config/cors.php
@@ -1,0 +1,34 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Cross-Origin Resource Sharing (CORS) Configuration
+    |--------------------------------------------------------------------------
+    |
+    | Here you may configure your settings for cross-origin resource sharing
+    | or "CORS". This determines what cross-origin operations may execute
+    | in web browsers. You are free to adjust these settings as needed.
+    |
+    | To learn more: https://developer.mozilla.org/en-US/docs/Web/HTTP/CORS
+    |
+    */
+
+    'paths' => ['*'],
+
+    'allowed_methods' => ['*'],
+
+    'allowed_origins' => [env('APP_URL', 'http://localhost')],
+
+    'allowed_origins_patterns' => [],
+
+    'allowed_headers' => ['*'],
+
+    'exposed_headers' => [],
+
+    'max_age' => 0,
+
+    'supports_credentials' => true,
+
+];

--- a/resources/views/admin/resources/show.blade.php
+++ b/resources/views/admin/resources/show.blade.php
@@ -61,9 +61,9 @@
         <x-detail-card 
             title="API情報"
             :data="[
-                ['label' => 'API URL', 'value' => url('/api/resources/' . $resource->id)],
-                ['label' => 'ダウンロード URL', 'value' => url('/api/resources/' . $resource->id . '/download')],
-                ['label' => 'ストリーミング URL', 'value' => url('/api/resources/' . $resource->id . '/stream')]
+                ['label' => 'API URL', 'value' => \App\Helpers\ApiHelper::url('resources/' . $resource->id)],
+                ['label' => 'ダウンロード URL', 'value' => \App\Helpers\ApiHelper::url('resources/' . $resource->id . '/download')],
+                ['label' => 'ストリーミング URL', 'value' => \App\Helpers\ApiHelper::url('resources/' . $resource->id . '/stream')]
             ]"
         >
             <div class="mt-4 border-t pt-4">
@@ -77,14 +77,14 @@
                     <div>
                         <p class="text-xs text-gray-600 mb-1">リソース情報を取得:</p>
                         <code class="block bg-gray-100 p-2 rounded text-xs">
-                            curl {{ url('/api/resources/' . $resource->id) }}
+                            curl {{ \App\Helpers\ApiHelper::url('resources/' . $resource->id) }}
                         </code>
                     </div>
                     
                     <div>
                         <p class="text-xs text-gray-600 mb-1">ファイルをダウンロード:</p>
                         <code class="block bg-gray-100 p-2 rounded text-xs">
-                            curl -O {{ url('/api/resources/' . $resource->id . '/download') }}
+                            curl -O {{ \App\Helpers\ApiHelper::url('resources/' . $resource->id . '/download') }}
                         </code>
                     </div>
                 </div>
@@ -114,21 +114,21 @@
                     <div>
                         <p class="text-xs text-gray-600 mb-1">リソース情報を取得（Authorizationヘッダー使用）:</p>
                         <code class="block bg-gray-100 p-2 rounded text-xs">
-                            curl -H "Authorization: Bearer YOUR_API_TOKEN" {{ url('/api/resources/' . $resource->id) }}
+                            curl -H "Authorization: Bearer YOUR_API_TOKEN" {{ \App\Helpers\ApiHelper::url('resources/' . $resource->id) }}
                         </code>
                     </div>
                     
                     <div>
                         <p class="text-xs text-gray-600 mb-1">ファイルをダウンロード（Authorizationヘッダー使用）:</p>
                         <code class="block bg-gray-100 p-2 rounded text-xs">
-                            curl -H "Authorization: Bearer YOUR_API_TOKEN" -O {{ url('/api/resources/' . $resource->id . '/download') }}
+                            curl -H "Authorization: Bearer YOUR_API_TOKEN" -O {{ \App\Helpers\ApiHelper::url('resources/' . $resource->id . '/download') }}
                         </code>
                     </div>
                     
                     <div>
                         <p class="text-xs text-gray-600 mb-1">ファイルをダウンロード（URLパラメータ使用）:</p>
                         <code class="block bg-gray-100 p-2 rounded text-xs">
-                            curl -O "{{ url('/api/resources/' . $resource->id . '/download') }}?token=YOUR_API_TOKEN"
+                            curl -O "{{ \App\Helpers\ApiHelper::url('resources/' . $resource->id . '/download') }}?token=YOUR_API_TOKEN"
                         </code>
                     </div>
                 </div>
@@ -151,12 +151,12 @@
                         
                         <p class="text-xs text-gray-600 mb-1">方法1: Authorizationヘッダー（推奨）</p>
                         <code class="block bg-gray-100 p-2 rounded text-xs mb-3">
-                            curl -H "Authorization: Bearer YOUR_API_TOKEN" {{ url('/api/resources/' . $resource->id . '/download') }}
+                            curl -H "Authorization: Bearer YOUR_API_TOKEN" {{ \App\Helpers\ApiHelper::url('resources/' . $resource->id . '/download') }}
                         </code>
                         
                         <p class="text-xs text-gray-600 mb-1">方法2: URLパラメータ</p>
                         <code class="block bg-gray-100 p-2 rounded text-xs mb-3">
-                            curl "{{ url('/api/resources/' . $resource->id . '/download') }}?token=YOUR_API_TOKEN"
+                            curl "{{ \App\Helpers\ApiHelper::url('resources/' . $resource->id . '/download') }}?token=YOUR_API_TOKEN"
                         </code>
                         
                         <div class="bg-blue-50 p-2 rounded mt-3">


### PR DESCRIPTION
## Summary
- APIエンドポイントを `/api` プレフィックスから `api.` サブドメインに移行しました
- 環境変数 `API_DOMAIN` でAPIサブドメインを設定可能にしました
- CORS設定を追加してクロスドメイン通信に対応しました

## Test plan
- [ ] ローカル環境で `/etc/hosts` に `127.0.0.1 api.localhost` を追加
- [ ] `http://api.localhost/resources` でAPIにアクセスできることを確認
- [ ] メインアプリケーションからAPIへの通信が正常に動作することを確認
- [ ] CORS設定により、クロスドメインリクエストが正常に処理されることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)